### PR TITLE
Improve voice recorder UI layout and waveform visualization

### DIFF
--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -362,47 +362,49 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
 
     const ui = (
       <div className="w-full flex justify-center pointer-events-auto">
-        <div className="relative flex items-center gap-4 px-4 py-3 rounded-2xl bg-transparent border border-[rgba(124,58,237,0.06)] max-w-3xl w-full mx-auto">
+        <div className="relative flex items-center gap-3 px-4 py-3 rounded-2xl bg-transparent border border-[rgba(124,58,237,0.06)] max-w-3xl w-full mx-auto">
           {/* Trash on the far left */}
           <button onClick={resetState} aria-label="Удалить запись" className="flex-none p-2 rounded-md bg-transparent text-white/70 hover:text-white transition-colors">
             <Trash2 className="h-5 w-5" />
           </button>
 
-          {/* Main area: waveform with centered play button */}
-          <div className="relative flex-1 flex items-center">
-            {/* Waveform / progress */}
-            <div className="relative w-full h-4 rounded-full bg-[rgba(255,255,255,0.03)] overflow-hidden">
-              {/* progress overlay */}
-              <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary to-primary/60" style={{ width: `${Math.round(previewProgress * 100)}%`, transition: 'width 120ms linear', mixBlendMode: 'screen', opacity: 0.6 }} />
+          {/* Waveform container */}
+          <div className="flex-1 flex items-center justify-center relative">
+            <div className="w-full max-w-[820px]">
+              <div className="relative h-10 rounded-md bg-[rgba(255,255,255,0.02)] overflow-hidden">
+                {/* progress overlay */}
+                <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary to-primary/60" style={{ width: `${Math.round(previewProgress * 100)}%`, transition: 'width 120ms linear', opacity: 0.45 }} />
 
-              {/* responsive bars */}
-              <div className="relative z-10 flex items-end justify-between h-full px-3">
-                <div className="flex items-end gap-2 w-full overflow-hidden">
-                  {previewLevels.map((lvl, i) => (
-                    <div
-                      key={i}
-                      style={{ height: `${Math.max(6, Math.round(lvl * 34))}px`, width: 6 }}
-                      className={`rounded-sm bg-gradient-to-t from-primary/90 to-primary/60 transition-all ${previewPlaying ? 'opacity-100' : 'opacity-60'}`}
-                    />
-                  ))}
+                {/* dynamic bars */}
+                <div className="relative z-10 h-full flex items-end justify-center px-2">
+                  <div className="flex items-end gap-[6px] w-full overflow-hidden justify-center">
+                    {previewLevels.map((lvl, i) => (
+                      <div
+                        key={i}
+                        style={{ height: `${Math.max(6, Math.round(lvl * 36))}px`, width: 6 }}
+                        className={`inline-block bg-gradient-to-t from-primary to-primary/60 rounded-sm transition-all ${previewPlaying ? 'opacity-100' : 'opacity-70'}`}
+                      />
+                    ))}
+                  </div>
                 </div>
+
+                {/* centered play button (overlay) */}
+                <button
+                  type="button"
+                  aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}
+                  onClick={() => setPreviewPlaying((p) => !p)}
+                  className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 inline-flex items-center justify-center h-10 w-10 rounded-full bg-white/6 text-white/90 hover:bg-white/8 transition-colors"
+                >
+                  {previewPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
+                </button>
+              </div>
+
+              <div className="mt-2 flex items-center justify-between text-xs text-white/80">
+                <span className="tabular-nums">{formatDuration(seconds)}</span>
+                {/* no send button per request - delete icon handles removal */}
               </div>
             </div>
-
-            {/* Play button centered over waveform */}
-            <button
-              type="button"
-              aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}
-              onClick={() => setPreviewPlaying((p) => !p)}
-              className="absolute left-1/2 -translate-x-1/2 -translate-y-1/2 inline-flex items-center justify-center h-10 w-10 rounded-full bg-white/6 text-white/90 hover:bg-white/8 transition-colors"
-              style={{ transform: 'translate(-50%, -50%)' }}
-            >
-              {previewPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
-            </button>
           </div>
-
-          {/* Duration on the right */}
-          <div className="tabular-nums text-xs text-white/80 ml-4 w-12 text-right">{formatDuration(seconds)}</div>
         </div>
       </div>
     );

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -327,41 +327,47 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
 
     const ui = (
       <div className="w-full flex justify-center pointer-events-auto">
-        <div className="flex items-center gap-4 px-4 py-3 rounded-2xl bg-gradient-to-r from-primary/20 to-primary/40 border border-[rgba(124,58,237,0.12)] shadow-glow max-w-3xl w-full mx-auto">
-          {/* Play/Pause */}
-          <button
-            type="button"
-            aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}
-            onClick={() => setPreviewPlaying((p) => !p)}
-            className="inline-flex items-center justify-center h-10 w-10 rounded-full bg-white/6 text-white/90 hover:bg-white/8 transition-colors"
-          >
-            {previewPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
+        <div className="relative flex items-center gap-4 px-4 py-3 rounded-2xl bg-transparent border border-[rgba(124,58,237,0.06)] max-w-3xl w-full mx-auto">
+          {/* Trash on the far left */}
+          <button onClick={resetState} aria-label="Удалить запись" className="flex-none p-2 rounded-md bg-transparent text-white/70 hover:text-white transition-colors">
+            <Trash2 className="h-5 w-5" />
           </button>
 
-          {/* Waveform / progress */}
-          <div className="flex-1 flex flex-col">
-            <div className="relative h-3 w-full rounded-full bg-white/6 overflow-hidden">
-              <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary to-primary/60" style={{ width: `${Math.round(previewProgress * 100)}%`, transition: 'width 120ms linear' }} />
-              <div className="relative z-10 flex items-center justify-between px-2">
-                <div className="flex items-center gap-[4px] w-full overflow-hidden">
+          {/* Main area: waveform with centered play button */}
+          <div className="relative flex-1 flex items-center">
+            {/* Waveform / progress */}
+            <div className="relative w-full h-4 rounded-full bg-[rgba(255,255,255,0.03)] overflow-hidden">
+              {/* progress overlay */}
+              <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary to-primary/60" style={{ width: `${Math.round(previewProgress * 100)}%`, transition: 'width 120ms linear', mixBlendMode: 'screen' }} />
+
+              {/* responsive bars */}
+              <div className="relative z-10 flex items-end justify-between h-full px-3">
+                <div className="flex items-end gap-2 w-full overflow-hidden">
                   {previewLevels.map((lvl, i) => (
                     <div
                       key={i}
-                      style={{ height: `${Math.max(3, Math.round(lvl * 14))}px`, width: 4 }}
-                      className={`rounded-full bg-white/90/30 transition-all ${previewPlaying ? 'opacity-90' : 'opacity-60'}`}
+                      style={{ height: `${Math.max(3, Math.round(lvl * 24))}px`, width: 6 }}
+                      className={`rounded-sm bg-gradient-to-t from-primary/90 to-primary/60 transition-all ${previewPlaying ? 'opacity-100' : 'opacity-60'}`}
                     />
                   ))}
                 </div>
               </div>
             </div>
-            <div className="flex items-center justify-between mt-2 text-xs text-white/80">
-              <span className="tabular-nums">{formatDuration(seconds)}</span>
-              <div className="flex items-center gap-3">
-                <button onClick={resetState} aria-label="Удалить запись" className="text-white/70 hover:text-white text-sm">Удалить</button>
-                <button onClick={sendRecording} aria-label="Отправить" className="inline-flex items-center justify-center h-8 px-3 rounded-full bg-gradient-to-br from-primary to-primary/70 text-white shadow-sm">Отправить</button>
-              </div>
-            </div>
+
+            {/* Play button centered over waveform */}
+            <button
+              type="button"
+              aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}
+              onClick={() => setPreviewPlaying((p) => !p)}
+              className="absolute left-1/2 -translate-x-1/2 -translate-y-1/2 inline-flex items-center justify-center h-10 w-10 rounded-full bg-white/6 text-white/90 hover:bg-white/8 transition-colors"
+              style={{ transform: 'translate(-50%, -50%)' }}
+            >
+              {previewPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
+            </button>
           </div>
+
+          {/* Duration on the right */}
+          <div className="tabular-nums text-xs text-white/80 ml-4 w-12 text-right">{formatDuration(seconds)}</div>
         </div>
       </div>
     );
@@ -374,7 +380,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
     }
 
     return ui;
-  }, [hasRecording, isRecording, recordedUrl, seconds, previewPlaying, previewProgress, resetState, sendRecording]);
+  }, [hasRecording, isRecording, recordedUrl, seconds, previewPlaying, previewProgress, resetState]);
 
   useEffect(() => {
     onRecordingState?.({ isRecording, seconds, cancelHint: cancelSwipe.active, cancelled: cancelSwipe.cancelled, hasRecording });

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -392,7 +392,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
             "px-2 py-1 rounded-md text-xs",
             cancelSwipe.cancelled ? "bg-red-500/20 text-red-400 border border-red-500/30" : "text-muted-foreground"
           )}>
-            {cancelSwipe.cancelled ? "Отпустите, чтобы отменить" : "Свайп влево — отмена"}
+            {cancelSwipe.cancelled ? "Отпус��ите, чтобы отменить" : "Свайп влево — отмена"}
           </div>
         </div>
         {cancelSwipe.active && (
@@ -420,8 +420,8 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
             <button onClick={resetState} aria-label="Удалить запись" className="p-2 rounded-md bg-transparent text-white/70 hover:text-white transition-colors">
               <Trash2 className="h-5 w-5" />
             </button>
-            <div aria-hidden className="p-2 rounded-md bg-transparent text-white/60">
-              <Send className="h-5 w-5" />
+            <div aria-hidden className="p-2 rounded-md bg-transparent">
+              <img src="/123.png" alt="logo" className="h-5 w-5 object-contain rounded-sm" />
             </div>
           </div>
 

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -49,6 +49,12 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   const dataArrayRef = useRef<Uint8Array | null>(null);
   const rafRef = useRef<number | null>(null);
   const [levels, setLevels] = useState<number[]>(() => new Array(16).fill(0));
+  // Preview waveform state and analyser refs
+  const [previewLevels, setPreviewLevels] = useState<number[]>(() => new Array(48).fill(0));
+  const previewAnalyserRef = useRef<AnalyserNode | null>(null);
+  const previewAudioCtxRef = useRef<AudioContext | null>(null);
+  const previewDataRef = useRef<Uint8Array | null>(null);
+  const previewRafRef = useRef<number | null>(null);
   const cancelledRef = useRef(false);
 
   const resetState = useCallback(() => {

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -326,24 +326,31 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
     if (!hasRecording || isRecording || !recordedUrl) return null;
     const ui = (
       <div className="w-full flex justify-center">
-        <div className="pointer-events-auto flex items-center gap-3 px-3 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[720px]">
+        <div className="relative pointer-events-auto flex items-center gap-4 px-4 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[720px]">
+          {/* Trash icon outside pill on the left, no background */}
+          <button onClick={resetState} aria-label="Удалить запись" className="absolute -left-10 top-1/2 transform -translate-y-1/2 text-white/70 hover:text-white transition-colors">
+            <Trash2 className="h-5 w-5" />
+          </button>
+
+          {/* Play inside circle */}
           <button
             type="button"
             aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}
             onClick={() => setPreviewPlaying((p) => !p)}
-            className="inline-flex items-center justify-center h-9 w-9 rounded-full bg-white/6 text-white/90 hover:bg-white/8 transition-colors"
+            className="inline-flex items-center justify-center h-10 w-10 rounded-full bg-white/6 text-white/90 hover:bg-white/8 transition-colors shadow-sm"
             style={{ flex: '0 0 auto' }}
           >
-            {previewPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+            {previewPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
           </button>
 
-          <div className="flex-1 mx-2">
-            <div className="relative h-8 w-full rounded-full bg-[rgba(255,255,255,0.02)] overflow-hidden flex items-end px-3">
-              <div className="flex items-end gap-[3px] w-full">
+          {/* Waveform centered */}
+          <div className="flex-1 mx-2 flex items-center justify-center">
+            <div className="relative h-8 w-full max-w-[560px] rounded-full bg-[rgba(255,255,255,0.02)] overflow-hidden flex items-end px-3">
+              <div className="flex items-end gap-[3px] mx-auto w-full max-w-full justify-center">
                 {previewLevels.map((lvl, i) => (
                   <div
                     key={i}
-                    style={{ height: `${Math.max(3, Math.round(lvl * 18))}px`, width: 2 }}
+                    style={{ height: `${Math.max(3, Math.round(lvl * 18))}px`, width: 3 }}
                     className={`rounded-full bg-white/30 transition-all ${previewPlaying ? 'opacity-100' : 'opacity-60'}`}
                   />
                 ))}
@@ -353,10 +360,6 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
           </div>
 
           <div className="tabular-nums text-xs text-white/80 ml-3 w-12 text-right">{formatDuration(seconds)}</div>
-
-          <button onClick={resetState} aria-label="Удалить запись" className="h-9 w-9 rounded-md bg-transparent border border-[rgba(255,255,255,0.04)] flex items-center justify-center text-white/80 hover:bg-white/6 ml-2 transition-colors">
-            <Trash2 className="h-4 w-4" />
-          </button>
 
           <audio ref={previewAudioRef} src={recordedUrl} preload="metadata" className="hidden" />
         </div>

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -85,7 +85,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
       window.clearInterval(timerRef.current);
       timerRef.current = null;
     }
-    // Stop recorder first — allow ondataavailable/onstop to run and gather data
+    // Stop recorder first ��� allow ondataavailable/onstop to run and gather data
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== "inactive") {
       try { mediaRecorderRef.current.stop(); } catch {}
     }
@@ -332,10 +332,10 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
             type="button"
             aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}
             onClick={() => setPreviewPlaying((p) => !p)}
-            className="inline-flex items-center justify-center h-9 w-9 rounded-full bg-white/8 text-white shadow-sm"
+            className="inline-flex items-center justify-center h-10 w-10 rounded-full bg-white/10 text-white shadow-md border border-[rgba(255,255,255,0.06)] hover:scale-105 transition-transform"
             style={{ flex: '0 0 auto' }}
           >
-            {previewPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+            {previewPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
           </button>
 
           <div className="flex-1 mx-2">

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -567,9 +567,13 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   }, [recordedUrl]);
 
   return (
-    <div className="inline-flex items-center gap-2 shrink-0 relative">
-      {ReadyToSendUI}
-      {hasText ? sendTextBtn : micBtn}
+    <div className="inline-flex items-center gap-3 shrink-0 relative w-full">
+      <div className="flex-1 flex justify-center">
+        {ReadyToSendUI}
+      </div>
+      <div className="flex items-center">
+        {hasRecording ? sendVoiceBtn : (hasText ? sendTextBtn : micBtn)}
+      </div>
     </div>
   );
 };

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -78,12 +78,16 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
       window.clearInterval(timerRef.current);
       timerRef.current = null;
     }
+    // Stop recorder first — allow ondataavailable/onstop to run and gather data
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== "inactive") {
       try { mediaRecorderRef.current.stop(); } catch {}
     }
     mediaRecorderRef.current = null;
-    mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
-    mediaStreamRef.current = null;
+    // Delay stopping tracks slightly to let browser emit dataavailable/onstop events
+    setTimeout(() => {
+      try { mediaStreamRef.current?.getTracks().forEach((t) => t.stop()); } catch {}
+      mediaStreamRef.current = null;
+    }, 120);
     stopVisualization();
   }, [stopVisualization]);
 
@@ -341,8 +345,8 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   }, [hasRecording, isRecording, recordedUrl, seconds, previewPlaying, previewProgress, resetState]);
 
   useEffect(() => {
-    onRecordingState?.({ isRecording, seconds, cancelHint: cancelSwipe.active, cancelled: cancelSwipe.cancelled });
-  }, [onRecordingState, isRecording, seconds, cancelSwipe.active, cancelSwipe.cancelled]);
+    onRecordingState?.({ isRecording, seconds, cancelHint: cancelSwipe.active, cancelled: cancelSwipe.cancelled, hasRecording });
+  }, [onRecordingState, isRecording, seconds, cancelSwipe.active, cancelSwipe.cancelled, hasRecording]);
 
   useEffect(() => {
     onBindApi?.({ cancel: cancelRecording, finish: finishRecording });

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -318,7 +318,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
 
   const ReadyToSendUI = useMemo(() => {
     if (!hasRecording || isRecording || !recordedUrl) return null;
-    return (
+    const ui = (
       <div className="flex-1 min-w-[200px]">
         <div className="flex items-center gap-3 px-4 py-3 rounded-2xl bg-card/80 border border-border/50 backdrop-blur-sm">
           <button
@@ -345,6 +345,13 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
         </div>
       </div>
     );
+    try {
+      const target = typeof document !== 'undefined' && document.getElementById('voice-preview-root');
+      if (target) return createPortal(ui, target);
+    } catch (e) {
+      // fall back to inline render
+    }
+    return ui;
   }, [hasRecording, isRecording, recordedUrl, seconds, previewPlaying, previewProgress, resetState]);
 
   useEffect(() => {

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -319,28 +319,47 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   const ReadyToSendUI = useMemo(() => {
     if (!hasRecording || isRecording || !recordedUrl) return null;
     const ui = (
-      <div className="w-full">
-        <div className="pointer-events-auto flex items-center gap-3 px-4 py-3 rounded-2xl bg-card/80 border border-border/50 backdrop-blur-sm w-full">
+      <div className="w-full flex justify-center">
+        <div className="pointer-events-auto flex items-center gap-3 px-3 py-2 rounded-full bg-gradient-to-r from-[#40284a] via-[#512b60] to-[#40284a] border border-[rgba(255,255,255,0.03)] w-full max-w-[720px]">
           <button
             type="button"
             aria-label="Удалить запись"
             onClick={resetState}
-            className="inline-flex items-center justify-center h-8 w-8 rounded-full bg-background/60 border border-border/60 hover:bg-background/80"
+            className="inline-flex items-center justify-center h-8 w-8 rounded-md bg-transparent text-muted-foreground hover:bg-white/5"
           >
             <Trash2 className="h-4 w-4" />
           </button>
+
           <button
             type="button"
             aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}
             onClick={() => setPreviewPlaying((p) => !p)}
-            className="inline-flex items-center justify-center h-8 w-8 rounded-full bg-primary/10 text-primary"
+            className="inline-flex items-center justify-center h-9 w-9 rounded-full bg-white/8 text-white shadow-sm"
+            style={{ flex: '0 0 auto' }}
           >
             {previewPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
           </button>
-          <div className="h-[3px] flex-1 rounded-full bg-border overflow-hidden mx-2">
-            <div className="h-full bg-primary" style={{ width: `${Math.round(previewProgress * 100)}%` }} />
+
+          <div className="flex-1 mx-2">
+            <div className="relative h-8 w-full rounded-full bg-[rgba(255,255,255,0.03)] overflow-hidden">
+              <div className="absolute inset-0 flex items-center px-3 gap-[4px]">
+                {Array.from({ length: 48 }).map((_, i) => {
+                  const h = Math.round(6 + 18 * (0.5 + 0.5 * Math.sin(i + previewProgress * 10)));
+                  return (
+                    <div
+                      key={i}
+                      style={{ height: `${h}px`, width: 3 }}
+                      className={`rounded-full bg-white/40 transition-all ${previewPlaying ? 'opacity-100' : 'opacity-60'}`}
+                    />
+                  );
+                })}
+              </div>
+              <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-[rgba(255,255,255,0.12)] to-transparent" style={{ width: `${Math.round(previewProgress * 100)}%`, pointerEvents: 'none' }} />
+            </div>
           </div>
-          <span className="tabular-nums text-sm text-foreground">{formatDuration(seconds)}</span>
+
+          <div className="tabular-nums text-sm text-white/90 ml-2 w-14 text-right">{formatDuration(seconds)}</div>
+
           <audio ref={previewAudioRef} src={recordedUrl} preload="metadata" className="hidden" />
         </div>
       </div>

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -229,7 +229,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
     <div className="relative">
       <button
         type="button"
-        aria-label="Записать голосо��ое"
+        aria-label="Записать голосовое"
         disabled={disabled || isRecording || hasRecording}
         onClick={() => startRecording()}
         className={cn(
@@ -269,7 +269,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   const sendTextBtn = (
     <button
       type="button"
-      aria-label="Отп��авить"
+      aria-label="Отправить"
       onClick={() => onSendText && onSendText()}
       disabled={disabled}
       className={cn(

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -255,7 +255,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   const sendVoiceBtn = (
     <button
       type="button"
-      aria-label="Отправить голосовое"
+      aria-label="Отправи��ь голосовое"
       onClick={sendRecording}
       className={cn(
         "inline-flex items-center justify-center h-10 w-10 rounded-full bg-gradient-primary text-white shadow-glow",
@@ -327,7 +327,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
 
     // Minimal, transparent 'checkbox' style preview positioned above the mic button.
     const ui = (
-      <div className="absolute -bottom-full mb-2 right-0 w-[320px] flex justify-end pointer-events-auto z-20">
+      <div className="absolute -bottom-full mb-2 left-1/2 -translate-x-1/2 w-[340px] flex justify-center pointer-events-auto z-20">
         <div className="flex items-center gap-3 px-3 py-2 rounded-lg border border-[rgba(255,255,255,0.06)] bg-transparent backdrop-blur-sm shadow-sm">
           {/* Play/Pause small */}
           <button

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -326,36 +326,44 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
     if (!hasRecording || isRecording || !recordedUrl) return null;
     const ui = (
       <div className="w-full flex justify-start">
-        <div className="relative pointer-events-auto flex items-center gap-4 px-4 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[640px] ml-2">
-          {/* Trash icon outside pill on the left, no background */}
-          <button onClick={resetState} aria-label="Удалить запись" className="flex-none p-1 rounded-md bg-transparent text-white/80 hover:text-white mr-2 transition-colors" style={{ pointerEvents: 'auto' }}>
+        <div className="relative pointer-events-auto flex items-center gap-4 px-3 py-3 rounded-2xl bg-gradient-to-r from-[#0B0B0D] to-[#0B0B0D]/60 border border-[rgba(255,255,255,0.03)] shadow-sm w-full max-w-[640px] ml-2">
+          {/* Delete button */}
+          <button onClick={resetState} aria-label="Удалить запись" className="flex-none p-2 rounded-md bg-transparent text-white/70 hover:text-white transition-colors" style={{ pointerEvents: 'auto' }}>
             <Trash2 className="h-4 w-4" />
           </button>
 
-          {/* Play inside circle */}
+          {/* Play/Pause */}
           <button
             type="button"
             aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}
             onClick={() => setPreviewPlaying((p) => !p)}
-            className="inline-flex items-center justify-center h-10 w-10 rounded-full bg-white/6 text-white/90 hover:bg-white/8 transition-colors shadow-sm"
+            className="inline-flex items-center justify-center h-10 w-10 rounded-full bg-gradient-to-br from-white/6 to-white/3 text-white/90 hover:from-white/8 hover:to-white/5 transition-transform shadow-sm"
             style={{ flex: '0 0 auto' }}
           >
             {previewPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
           </button>
 
-          {/* Waveform centered */}
-          <div className="flex-1 mx-2 flex items-center justify-center">
-            <div className="relative h-8 w-full max-w-[480px] rounded-full bg-[rgba(255,255,255,0.02)] overflow-hidden flex items-end px-3">
-              <div className="flex items-end gap-[3px] mx-auto w-full max-w-full justify-center">
+          {/* Waveform */}
+          <div className="flex-1 mx-2 flex items-center">
+            <div className="relative h-10 w-full max-w-[480px] rounded-xl bg-[rgba(255,255,255,0.02)] overflow-hidden flex items-center px-3">
+              {/* Progress overlay */}
+              <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary/40 to-transparent" style={{ width: `${Math.round(previewProgress * 100)}%`, pointerEvents: 'none', mixBlendMode: 'screen' }} />
+
+              {/* Bars */}
+              <div className="relative z-10 flex items-end gap-[4px] w-full">
                 {previewLevels.map((lvl, i) => (
                   <div
                     key={i}
-                    style={{ height: `${Math.max(3, Math.round(lvl * 18))}px`, width: 3 }}
-                    className={`rounded-full bg-white/30 transition-all ${previewPlaying ? 'opacity-100' : 'opacity-60'}`}
+                    style={{ height: `${Math.max(4, Math.round(lvl * 28))}px`, width: 4, borderRadius: 4 }}
+                    className={`bg-gradient-to-t from-primary to-primary/50 transition-all ${previewPlaying ? 'opacity-100' : 'opacity-60'}`}
                   />
                 ))}
               </div>
-              <div className="absolute left-0 top-0 h-full bg-white/10" style={{ width: `${Math.round(previewProgress * 100)}%`, mixBlendMode: 'overlay', pointerEvents: 'none' }} />
+
+              {/* Subtle baseline */}
+              <div className="absolute inset-0 pointer-events-none flex items-center justify-center">
+                <div className="h-[2px] w-full bg-white/6 rounded" />
+              </div>
             </div>
           </div>
 

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -345,7 +345,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
 
           {/* Waveform centered */}
           <div className="flex-1 mx-2 flex items-center justify-center">
-            <div className="relative h-8 w-full max-w-[560px] rounded-full bg-[rgba(255,255,255,0.02)] overflow-hidden flex items-end px-3">
+            <div className="relative h-8 w-full max-w-[480px] rounded-full bg-[rgba(255,255,255,0.02)] overflow-hidden flex items-end px-3">
               <div className="flex items-end gap-[3px] mx-auto w-full max-w-full justify-center">
                 {previewLevels.map((lvl, i) => (
                   <div

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -349,7 +349,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
         "hover:scale-105 active:scale-95 transition-transform"
       )}
     >
-      <Send className="h-4 w-4" />
+      <Send className="h-5 w-5" />
     </button>
   );
 
@@ -364,7 +364,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
         "hover:scale-105 active:scale-95 transition-transform disabled:opacity-50"
       )}
     >
-      <Send className="h-4 w-4" />
+      <Send className="h-5 w-5" />
     </button>
   );
 
@@ -392,7 +392,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
             "px-2 py-1 rounded-md text-xs",
             cancelSwipe.cancelled ? "bg-red-500/20 text-red-400 border border-red-500/30" : "text-muted-foreground"
           )}>
-            {cancelSwipe.cancelled ? "Отпус��ите, чтобы отменить" : "Свайп влево — отмена"}
+            {cancelSwipe.cancelled ? "Отпустите, чтобы отменить" : "Свайп влево — отмена"}
           </div>
         </div>
         {cancelSwipe.active && (

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -326,7 +326,8 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
     if (!hasRecording || isRecording || !recordedUrl) return null;
     const ui = (
       <div className="w-full flex justify-center">
-        <div className="pointer-events-auto flex items-center gap-3 px-3 py-2 rounded-full bg-gradient-to-r from-[#40284a] via-[#512b60] to-[#40284a] border border-[rgba(255,255,255,0.03)] w-full max-w-[720px]">
+        <div className="pointer-events-auto flex items-center gap-4 px-4 py-3 rounded-2xl bg-gradient-to-r from-[rgba(90,45,90,0.55)] to-[rgba(60,25,60,0.45)] shadow-lg border border-[rgba(255,255,255,0.04)] w-full max-w-[760px]">
+          {/* trash inside pill — larger and spaced */}
           <button
             type="button"
             aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -326,7 +326,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
     if (!hasRecording || isRecording || !recordedUrl) return null;
     const ui = (
       <div className="w-full flex justify-center">
-        <div className="relative pointer-events-auto flex items-center gap-4 px-4 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[720px]">
+        <div className="relative pointer-events-auto flex items-center gap-4 px-4 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[640px]">
           {/* Trash icon outside pill on the left, no background */}
           <button onClick={resetState} aria-label="Удалить запись" className="absolute -left-10 top-1/2 transform -translate-y-1/2 text-white/70 hover:text-white transition-colors">
             <Trash2 className="h-5 w-5" />

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -328,8 +328,8 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
       <div className="w-full flex justify-start">
         <div className="relative pointer-events-auto flex items-center gap-4 px-4 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[640px] ml-2">
           {/* Trash icon outside pill on the left, no background */}
-          <button onClick={resetState} aria-label="Удалить запись" className="flex-none p-1 rounded-md bg-background/80 border border-border/30 text-white/90 hover:bg-background/90 mr-2 transition-colors" style={{ pointerEvents: 'auto' }}>
-            <Trash2 className="h-5 w-5" />
+          <button onClick={resetState} aria-label="Удалить запись" className="flex-none p-1 rounded-md bg-transparent text-white/80 hover:text-white mr-2 transition-colors" style={{ pointerEvents: 'auto' }}>
+            <Trash2 className="h-4 w-4" />
           </button>
 
           {/* Play inside circle */}

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -373,7 +373,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
             "px-2 py-1 rounded-md text-xs",
             cancelSwipe.cancelled ? "bg-red-500/20 text-red-400 border border-red-500/30" : "text-muted-foreground"
           )}>
-            {cancelSwipe.cancelled ? "Отпустите, чтобы отменить" : "Свайп влево — отмена"}
+            {cancelSwipe.cancelled ? "Отпу��тите, чтобы отменить" : "Свайп влево — отмена"}
           </div>
         </div>
         {cancelSwipe.active && (
@@ -401,10 +401,6 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
             <button onClick={resetState} aria-label="Удалить запись" className="p-2 rounded-md bg-transparent text-white/70 hover:text-white transition-colors">
               <Trash2 className="h-5 w-5" />
             </button>
-            <div aria-hidden className="p-2 rounded-md bg-transparent text-white/50">
-              {/* non-interactive forward/play-next icon */}
-              <Play className="h-5 w-5" />
-            </div>
           </div>
 
           {/* Waveform container (smaller) */}

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -328,7 +328,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
       <div className="w-full flex justify-center">
         <div className="relative pointer-events-auto flex items-center gap-4 px-4 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[640px]">
           {/* Trash icon outside pill on the left, no background */}
-          <button onClick={resetState} aria-label="Удалить запись" className="absolute -left-10 top-1/2 transform -translate-y-1/2 text-white/70 hover:text-white transition-colors">
+          <button onClick={resetState} aria-label="Удалить запись" className="absolute -left-8 top-1/2 transform -translate-y-1/2 text-white/70 hover:text-white transition-colors">
             <Trash2 className="h-5 w-5" />
           </button>
 

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -328,7 +328,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
       <div className="w-full flex justify-center">
         <div className="relative pointer-events-auto flex items-center gap-4 px-4 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[640px]">
           {/* Trash icon outside pill on the left, no background */}
-          <button onClick={resetState} aria-label="Удалить запись" className="text-white/70 hover:text-white transition-colors mr-2 flex-none">
+          <button onClick={resetState} aria-label="Удалить запись" className="absolute -left-12 top-1/2 transform -translate-y-1/2 text-white/90 hover:text-white transition-colors flex-none p-1 rounded-md bg-transparent" style={{ pointerEvents: 'auto' }}>
             <Trash2 className="h-5 w-5" />
           </button>
 

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -269,7 +269,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   const sendTextBtn = (
     <button
       type="button"
-      aria-label="Отправить"
+      aria-label="Отп��авить"
       onClick={() => onSendText && onSendText()}
       disabled={disabled}
       className={cn(
@@ -328,7 +328,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
       <div className="w-full flex justify-center">
         <div className="relative pointer-events-auto flex items-center gap-4 px-4 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[640px]">
           {/* Trash icon outside pill on the left, no background */}
-          <button onClick={resetState} aria-label="Удалить запись" className="absolute -left-12 top-1/2 transform -translate-y-1/2 text-white/90 hover:text-white transition-colors flex-none p-1 rounded-md bg-transparent" style={{ pointerEvents: 'auto' }}>
+          <button onClick={resetState} aria-label="Удалить запись" className="flex-none p-1 rounded-md bg-background/80 border border-border/30 text-white/90 hover:bg-background/90 mr-2 transition-colors" style={{ pointerEvents: 'auto' }}>
             <Trash2 className="h-5 w-5" />
           </button>
 

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -328,7 +328,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
       <div className="w-full flex justify-center">
         <div className="relative pointer-events-auto flex items-center gap-4 px-4 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[640px]">
           {/* Trash icon outside pill on the left, no background */}
-          <button onClick={resetState} aria-label="Удалить запись" className="absolute -left-8 top-1/2 transform -translate-y-1/2 text-white/70 hover:text-white transition-colors">
+          <button onClick={resetState} aria-label="Удалить запись" className="text-white/70 hover:text-white transition-colors mr-2 flex-none">
             <Trash2 className="h-5 w-5" />
           </button>
 

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -319,8 +319,8 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   const ReadyToSendUI = useMemo(() => {
     if (!hasRecording || isRecording || !recordedUrl) return null;
     const ui = (
-      <div className="flex-1 min-w-[200px]">
-        <div className="flex items-center gap-3 px-4 py-3 rounded-2xl bg-card/80 border border-border/50 backdrop-blur-sm">
+      <div className="w-full">
+        <div className="pointer-events-auto flex items-center gap-3 px-4 py-3 rounded-2xl bg-card/80 border border-border/50 backdrop-blur-sm w-full">
           <button
             type="button"
             aria-label="Удалить запись"
@@ -337,7 +337,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
           >
             {previewPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
           </button>
-          <div className="h-[3px] flex-1 rounded-full bg-border overflow-hidden">
+          <div className="h-[3px] flex-1 rounded-full bg-border overflow-hidden mx-2">
             <div className="h-full bg-primary" style={{ width: `${Math.round(previewProgress * 100)}%` }} />
           </div>
           <span className="tabular-nums text-sm text-foreground">{formatDuration(seconds)}</span>

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -543,13 +543,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   return (
     <div className="inline-flex items-center gap-2 shrink-0 relative">
       {ReadyToSendUI}
-      {hasRecording ? (
-        <>
-          {sendVoiceBtn}
-        </>
-      ) : (
-        hasText ? sendTextBtn : micBtn
-      )}
+      {hasText ? sendTextBtn : micBtn}
     </div>
   );
 };

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -395,30 +395,36 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
 
     const ui = (
       <div className="w-full flex justify-center pointer-events-auto">
-        <div className="relative flex items-center gap-3 px-4 py-3 rounded-2xl bg-transparent border border-[rgba(124,58,237,0.06)] max-w-3xl w-full mx-auto">
-          {/* Trash on the far left */}
-          <button onClick={resetState} aria-label="Удалить запись" className="flex-none p-2 rounded-md bg-transparent text-white/70 hover:text-white transition-colors">
-            <Trash2 className="h-5 w-5" />
-          </button>
+        <div className="relative flex items-center gap-3 px-3 py-3 rounded-2xl bg-transparent border border-[rgba(124,58,237,0.04)] max-w-3xl w-full mx-auto">
+          {/* Left controls inside input: trash + forward (non-clickable) */}
+          <div className="flex items-center gap-2 flex-none pl-1">
+            <button onClick={resetState} aria-label="Удалить запись" className="p-2 rounded-md bg-transparent text-white/70 hover:text-white transition-colors">
+              <Trash2 className="h-5 w-5" />
+            </button>
+            <div aria-hidden className="p-2 rounded-md bg-transparent text-white/50">
+              {/* non-interactive forward/play-next icon */}
+              <Play className="h-5 w-5" />
+            </div>
+          </div>
 
-          {/* Waveform container */}
+          {/* Waveform container (smaller) */}
           <div className="flex-1 flex items-center justify-center relative">
-            <div className="w-full max-w-[820px]">
-              <div className="relative h-12 rounded-md bg-primary/6 overflow-hidden">
+            <div className="w-full max-w-[760px]">
+              <div className="relative h-8 rounded-md bg-[rgba(255,255,255,0.02)] overflow-hidden">
                 {/* progress overlay */}
                 <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary to-primary/60" style={{ width: `${Math.round(previewProgress * 100)}%`, transition: 'width 120ms linear', opacity: 0.35 }} />
 
-                {/* canvas waveform */}
+                {/* canvas waveform centered */}
                 <div className="relative z-10 h-full flex items-center justify-center px-2">
                   <canvas ref={previewCanvasRef} style={{ width: '100%', height: '100%' }} />
                 </div>
 
-                {/* centered play button (overlay) */}
+                {/* centered play button (overlay) - slightly smaller icon */}
                 <button
                   type="button"
                   aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}
                   onClick={() => setPreviewPlaying((p) => !p)}
-                  className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 inline-flex items-center justify-center h-10 w-10 rounded-full bg-white/6 text-white/90 hover:bg-white/8 transition-colors"
+                  className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 inline-flex items-center justify-center h-8 w-8 rounded-full bg-white/6 text-white/90 hover:bg-white/8 transition-colors"
                 >
                   {previewPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
                 </button>

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -325,8 +325,8 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   const ReadyToSendUI = useMemo(() => {
     if (!hasRecording || isRecording || !recordedUrl) return null;
     const ui = (
-      <div className="w-full flex justify-center">
-        <div className="relative pointer-events-auto flex items-center gap-4 px-4 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[640px]">
+      <div className="w-full flex justify-start">
+        <div className="relative pointer-events-auto flex items-center gap-4 px-4 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[640px] ml-2">
           {/* Trash icon outside pill on the left, no background */}
           <button onClick={resetState} aria-label="Удалить запись" className="flex-none p-1 rounded-md bg-background/80 border border-border/30 text-white/90 hover:bg-background/90 mr-2 transition-colors" style={{ pointerEvents: 'auto' }}>
             <Trash2 className="h-5 w-5" />

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -381,7 +381,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
                   {previewLevels.map((lvl, i) => (
                     <div
                       key={i}
-                      style={{ height: `${Math.max(3, Math.round(lvl * 24))}px`, width: 6 }}
+                      style={{ height: `${Math.max(6, Math.round(lvl * 34))}px`, width: 6 }}
                       className={`rounded-sm bg-gradient-to-t from-primary/90 to-primary/60 transition-all ${previewPlaying ? 'opacity-100' : 'opacity-60'}`}
                     />
                   ))}

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -414,17 +414,20 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
 
     const ui = (
       <div className="w-full flex justify-center pointer-events-auto">
-        <div className="relative flex items-center gap-3 px-3 py-3 rounded-2xl bg-transparent border border-[rgba(124,58,237,0.04)] max-w-3xl w-full mx-auto">
-          {/* Left controls inside input: trash + forward (non-clickable) */}
+        <div className="relative flex items-center gap-3 px-3 py-3 rounded-2xl bg-transparent border border-[rgba(124,58,237,0.04)] w-full mx-auto" style={{ maxWidth: 'calc(100% - 160px)' }}>
+          {/* Left controls inside input: trash + small arrow (non-interactive) */}
           <div className="flex items-center gap-2 flex-none pl-1">
             <button onClick={resetState} aria-label="Удалить запись" className="p-2 rounded-md bg-transparent text-white/70 hover:text-white transition-colors">
               <Trash2 className="h-5 w-5" />
             </button>
+            <div aria-hidden className="p-2 rounded-md bg-transparent text-white/60">
+              <Send className="h-5 w-5" />
+            </div>
           </div>
 
           {/* Waveform container (smaller) */}
           <div className="flex-1 flex items-center justify-center relative">
-            <div className="w-full max-w-[760px]">
+            <div className="w-full max-w-[620px]">
               <div className="relative h-8 rounded-md bg-[rgba(255,255,255,0.02)] overflow-hidden">
                 {/* progress overlay */}
                 <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary to-primary/60" style={{ width: `${Math.round(previewProgress * 100)}%`, transition: 'width 120ms linear', opacity: 0.35 }} />

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -38,6 +38,27 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   const [previewPlaying, setPreviewPlaying] = useState(false);
   const [previewProgress, setPreviewProgress] = useState(0);
 
+
+  // Recorder
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const timerRef = useRef<number | null>(null);
+
+  // Visualization
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const dataArrayRef = useRef<Uint8Array | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const [levels, setLevels] = useState<number[]>(() => new Array(16).fill(0));
+  // Preview waveform state and analyser refs
+  const [previewLevels, setPreviewLevels] = useState<number[]>(() => new Array(48).fill(0));
+  const previewAnalyserRef = useRef<AnalyserNode | null>(null);
+  const previewAudioCtxRef = useRef<AudioContext | null>(null);
+  const previewDataRef = useRef<Uint8Array | null>(null);
+  const previewRafRef = useRef<number | null>(null);
+  const cancelledRef = useRef(false);
+
   // draw waveform to canvas when previewLevels change
   useEffect(() => {
     const canvas = previewCanvasRef.current;
@@ -68,26 +89,6 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
       x += barWidth + gap;
     }
   }, [previewLevels]);
-
-  // Recorder
-  const mediaStreamRef = useRef<MediaStream | null>(null);
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const chunksRef = useRef<Blob[]>([]);
-  const timerRef = useRef<number | null>(null);
-
-  // Visualization
-  const analyserRef = useRef<AnalyserNode | null>(null);
-  const audioCtxRef = useRef<AudioContext | null>(null);
-  const dataArrayRef = useRef<Uint8Array | null>(null);
-  const rafRef = useRef<number | null>(null);
-  const [levels, setLevels] = useState<number[]>(() => new Array(16).fill(0));
-  // Preview waveform state and analyser refs
-  const [previewLevels, setPreviewLevels] = useState<number[]>(() => new Array(48).fill(0));
-  const previewAnalyserRef = useRef<AnalyserNode | null>(null);
-  const previewAudioCtxRef = useRef<AudioContext | null>(null);
-  const previewDataRef = useRef<Uint8Array | null>(null);
-  const previewRafRef = useRef<number | null>(null);
-  const cancelledRef = useRef(false);
 
   const resetState = useCallback(() => {
     setIsRecording(false);

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -373,7 +373,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
             {/* Waveform / progress */}
             <div className="relative w-full h-4 rounded-full bg-[rgba(255,255,255,0.03)] overflow-hidden">
               {/* progress overlay */}
-              <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary to-primary/60" style={{ width: `${Math.round(previewProgress * 100)}%`, transition: 'width 120ms linear', mixBlendMode: 'screen' }} />
+              <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary to-primary/60" style={{ width: `${Math.round(previewProgress * 100)}%`, transition: 'width 120ms linear', mixBlendMode: 'screen', opacity: 0.6 }} />
 
               {/* responsive bars */}
               <div className="relative z-10 flex items-end justify-between h-full px-3">

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -326,39 +326,37 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
     if (!hasRecording || isRecording || !recordedUrl) return null;
     const ui = (
       <div className="w-full flex justify-center">
-        <div className="pointer-events-auto flex items-center gap-4 px-4 py-3 rounded-2xl bg-gradient-to-r from-[rgba(90,45,90,0.55)] to-[rgba(60,25,60,0.45)] shadow-lg border border-[rgba(255,255,255,0.04)] w-full max-w-[760px]">
-          {/* trash inside pill — larger and spaced */}
+        <div className="pointer-events-auto flex items-center gap-3 px-3 py-2 rounded-full bg-[#0B0B0D] border border-[rgba(255,255,255,0.04)] shadow-sm w-full max-w-[720px]">
           <button
             type="button"
             aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}
             onClick={() => setPreviewPlaying((p) => !p)}
-            className="inline-flex items-center justify-center h-10 w-10 rounded-full bg-white/10 text-white shadow-md border border-[rgba(255,255,255,0.06)] hover:scale-105 transition-transform"
+            className="inline-flex items-center justify-center h-9 w-9 rounded-full bg-white/6 text-white/90 hover:bg-white/8 transition-colors"
             style={{ flex: '0 0 auto' }}
           >
-            {previewPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
+            {previewPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
           </button>
 
-          <div className="flex-1 mx-2 relative">
-            <div className="absolute -left-12 top-1/2 transform -translate-y-1/2">
-              <button onClick={resetState} aria-label="Удалить запись" className="h-9 w-9 rounded-md bg-white/6 flex items-center justify-center text-white/80 hover:bg-white/10 transition-colors">
-                <Trash2 className="h-5 w-5" />
-              </button>
-            </div>
-            <div className="relative h-10 w-full rounded-full bg-[rgba(255,255,255,0.03)] overflow-hidden px-3 flex items-center">
-              <div className="flex items-end gap-[4px] w-full">
+          <div className="flex-1 mx-2">
+            <div className="relative h-8 w-full rounded-full bg-[rgba(255,255,255,0.02)] overflow-hidden flex items-end px-3">
+              <div className="flex items-end gap-[3px] w-full">
                 {previewLevels.map((lvl, i) => (
                   <div
                     key={i}
-                    style={{ height: `${Math.max(4, Math.round(lvl * 28))}px`, width: 4 }}
-                    className={`rounded-full bg-white/40 transition-all ${previewPlaying ? 'opacity-100' : 'opacity-60'}`}
+                    style={{ height: `${Math.max(3, Math.round(lvl * 18))}px`, width: 2 }}
+                    className={`rounded-full bg-white/30 transition-all ${previewPlaying ? 'opacity-100' : 'opacity-60'}`}
                   />
                 ))}
               </div>
-              <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-[rgba(255,255,255,0.12)] to-transparent" style={{ width: `${Math.round(previewProgress * 100)}%`, pointerEvents: 'none' }} />
+              <div className="absolute left-0 top-0 h-full bg-white/10" style={{ width: `${Math.round(previewProgress * 100)}%`, mixBlendMode: 'overlay', pointerEvents: 'none' }} />
             </div>
           </div>
 
-          <div className="tabular-nums text-sm text-white/90 ml-4 w-16 text-right">{formatDuration(seconds)}</div>
+          <div className="tabular-nums text-xs text-white/80 ml-3 w-12 text-right">{formatDuration(seconds)}</div>
+
+          <button onClick={resetState} aria-label="Удалить запись" className="h-9 w-9 rounded-md bg-transparent border border-[rgba(255,255,255,0.04)] flex items-center justify-center text-white/80 hover:bg-white/6 ml-2 transition-colors">
+            <Trash2 className="h-4 w-4" />
+          </button>
 
           <audio ref={previewAudioRef} src={recordedUrl} preload="metadata" className="hidden" />
         </div>

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -392,7 +392,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
             "px-2 py-1 rounded-md text-xs",
             cancelSwipe.cancelled ? "bg-red-500/20 text-red-400 border border-red-500/30" : "text-muted-foreground"
           )}>
-            {cancelSwipe.cancelled ? "Отпустите, чтобы отменить" : "Свайп влево — отмена"}
+            {cancelSwipe.cancelled ? "Отпустите, чтобы отменить" : "Свайп вл��во — отмена"}
           </div>
         </div>
         {cancelSwipe.active && (
@@ -592,10 +592,8 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
   }, [recordedUrl]);
 
   return (
-    <div className="inline-flex items-center gap-3 shrink-0 relative w-full">
-      <div className="flex-1 flex justify-center">
-        {ReadyToSendUI}
-      </div>
+    <div className="inline-flex items-center gap-2 relative">
+      {/* ReadyToSendUI is rendered into #voice-preview-root via portal; keep component compact here */}
       <div className="flex items-center">
         {hasRecording ? sendVoiceBtn : (hasText ? sendTextBtn : micBtn)}
       </div>

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -143,6 +143,8 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
         setHasRecording(true);
         setPreviewPlaying(false);
         setPreviewProgress(0);
+        // mark recording finished so UI can show preview
+        setIsRecording(false);
       };
       recorder.start();
       cancelledRef.current = false;

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Send, Mic, Trash2, Play, Pause } from "lucide-react";
 import { cn } from "@/lib/utils";
 

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -85,7 +85,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
       window.clearInterval(timerRef.current);
       timerRef.current = null;
     }
-    // Stop recorder first ��� allow ondataavailable/onstop to run and gather data
+    // Stop recorder first — allow ondataavailable/onstop to run and gather data
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== "inactive") {
       try { mediaRecorderRef.current.stop(); } catch {}
     }
@@ -338,13 +338,18 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
             {previewPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
           </button>
 
-          <div className="flex-1 mx-2">
-            <div className="relative h-8 w-full rounded-full bg-[rgba(255,255,255,0.03)] overflow-hidden">
-              <div className="absolute inset-0 flex items-end px-3 gap-[4px]">
+          <div className="flex-1 mx-2 relative">
+            <div className="absolute -left-12 top-1/2 transform -translate-y-1/2">
+              <button onClick={resetState} aria-label="Удалить запись" className="h-9 w-9 rounded-md bg-white/6 flex items-center justify-center text-white/80 hover:bg-white/10 transition-colors">
+                <Trash2 className="h-5 w-5" />
+              </button>
+            </div>
+            <div className="relative h-10 w-full rounded-full bg-[rgba(255,255,255,0.03)] overflow-hidden px-3 flex items-center">
+              <div className="flex items-end gap-[4px] w-full">
                 {previewLevels.map((lvl, i) => (
                   <div
                     key={i}
-                    style={{ height: `${Math.max(4, Math.round(lvl * 28))}px`, width: 3 }}
+                    style={{ height: `${Math.max(4, Math.round(lvl * 28))}px`, width: 4 }}
                     className={`rounded-full bg-white/40 transition-all ${previewPlaying ? 'opacity-100' : 'opacity-60'}`}
                   />
                 ))}
@@ -353,7 +358,7 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
             </div>
           </div>
 
-          <div className="tabular-nums text-sm text-white/90 ml-2 w-14 text-right">{formatDuration(seconds)}</div>
+          <div className="tabular-nums text-sm text-white/90 ml-4 w-16 text-right">{formatDuration(seconds)}</div>
 
           <audio ref={previewAudioRef} src={recordedUrl} preload="metadata" className="hidden" />
         </div>

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -406,6 +406,8 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
             </div>
           </div>
         </div>
+        {/* hidden audio element used for preview playback / analyser */}
+        <audio ref={previewAudioRef} src={recordedUrl || undefined} preload="metadata" className="hidden" />
       </div>
     );
 

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -324,61 +324,37 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
 
   const ReadyToSendUI = useMemo(() => {
     if (!hasRecording || isRecording || !recordedUrl) return null;
-    const ui = (
-      <div className="w-full flex justify-start">
-        <div className="relative pointer-events-auto flex items-center gap-4 px-3 py-3 rounded-2xl bg-gradient-to-r from-[#0B0B0D] to-[#0B0B0D]/60 border border-[rgba(255,255,255,0.03)] shadow-sm w-full max-w-[640px] ml-2">
-          {/* Delete button */}
-          <button onClick={resetState} aria-label="Удалить запись" className="flex-none p-2 rounded-md bg-transparent text-white/70 hover:text-white transition-colors" style={{ pointerEvents: 'auto' }}>
-            <Trash2 className="h-4 w-4" />
-          </button>
 
-          {/* Play/Pause */}
+    // Minimal, transparent 'checkbox' style preview positioned above the mic button.
+    const ui = (
+      <div className="absolute -bottom-full mb-2 right-0 w-[320px] flex justify-end pointer-events-auto z-20">
+        <div className="flex items-center gap-3 px-3 py-2 rounded-lg border border-[rgba(255,255,255,0.06)] bg-transparent backdrop-blur-sm shadow-sm">
+          {/* Play/Pause small */}
           <button
             type="button"
             aria-label={previewPlaying ? "Пауза" : "Воспроизвести"}
             onClick={() => setPreviewPlaying((p) => !p)}
-            className="inline-flex items-center justify-center h-10 w-10 rounded-full bg-gradient-to-br from-white/6 to-white/3 text-white/90 hover:from-white/8 hover:to-white/5 transition-transform shadow-sm"
-            style={{ flex: '0 0 auto' }}
+            className="inline-flex items-center justify-center h-8 w-8 rounded-full bg-white/3 text-white/90 hover:bg-white/5 transition-colors"
           >
-            {previewPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
+            {previewPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
           </button>
 
-          {/* Waveform */}
-          <div className="flex-1 mx-2 flex items-center">
-            <div className="relative h-10 w-full max-w-[480px] rounded-xl bg-[rgba(255,255,255,0.02)] overflow-hidden flex items-center px-3">
-              {/* Progress overlay */}
-              <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary/40 to-transparent" style={{ width: `${Math.round(previewProgress * 100)}%`, pointerEvents: 'none', mixBlendMode: 'screen' }} />
-
-              {/* Bars */}
-              <div className="relative z-10 flex items-end gap-[4px] w-full">
-                {previewLevels.map((lvl, i) => (
-                  <div
-                    key={i}
-                    style={{ height: `${Math.max(4, Math.round(lvl * 28))}px`, width: 4, borderRadius: 4 }}
-                    className={`bg-gradient-to-t from-primary to-primary/50 transition-all ${previewPlaying ? 'opacity-100' : 'opacity-60'}`}
-                  />
-                ))}
-              </div>
-
-              {/* Subtle baseline */}
-              <div className="absolute inset-0 pointer-events-none flex items-center justify-center">
-                <div className="h-[2px] w-full bg-white/6 rounded" />
-              </div>
+          {/* Simple dotted progress bar (no heavy fill) */}
+          <div className="flex-1 px-1">
+            <div className="h-2 w-full bg-transparent rounded overflow-hidden">
+              <div className="h-2 rounded bg-gradient-to-r from-primary to-primary/60" style={{ width: `${Math.round(previewProgress * 100)}%` }} />
+            </div>
+            <div className="flex items-center justify-between text-xs text-white/70 mt-1">
+              <span className="tabular-nums">{formatDuration(seconds)}</span>
+              <button onClick={resetState} aria-label="Удалить запись" className="text-white/60 hover:text-white text-sm">Удалить</button>
             </div>
           </div>
-
-          <div className="tabular-nums text-xs text-white/80 ml-3 w-12 text-right">{formatDuration(seconds)}</div>
-
-          <audio ref={previewAudioRef} src={recordedUrl} preload="metadata" className="hidden" />
         </div>
       </div>
     );
-    try {
-      const target = typeof document !== 'undefined' && document.getElementById('voice-preview-root');
-      if (target) return createPortal(ui, target);
-    } catch (e) {
-      // fall back to inline render
-    }
+
+    // Render inline (positioned absolute relative to VoiceRecorder root). This avoids
+    // using the global portal so the preview sits directly above the microphone button.
     return ui;
   }, [hasRecording, isRecording, recordedUrl, seconds, previewPlaying, previewProgress, resetState]);
 

--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -403,21 +403,13 @@ const VoiceRecorder: React.FC<VoiceRecorderProps> = ({ onSend, disabled, hasText
           {/* Waveform container */}
           <div className="flex-1 flex items-center justify-center relative">
             <div className="w-full max-w-[820px]">
-              <div className="relative h-10 rounded-md bg-[rgba(255,255,255,0.02)] overflow-hidden">
+              <div className="relative h-12 rounded-md bg-primary/6 overflow-hidden">
                 {/* progress overlay */}
-                <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary to-primary/60" style={{ width: `${Math.round(previewProgress * 100)}%`, transition: 'width 120ms linear', opacity: 0.45 }} />
+                <div className="absolute left-0 top-0 h-full bg-gradient-to-r from-primary to-primary/60" style={{ width: `${Math.round(previewProgress * 100)}%`, transition: 'width 120ms linear', opacity: 0.35 }} />
 
-                {/* dynamic bars */}
-                <div className="relative z-10 h-full flex items-end justify-center px-2">
-                  <div className="flex items-end gap-[6px] w-full overflow-hidden justify-center">
-                    {previewLevels.map((lvl, i) => (
-                      <div
-                        key={i}
-                        style={{ height: `${Math.max(6, Math.round(lvl * 36))}px`, width: 6 }}
-                        className={`inline-block bg-gradient-to-t from-primary to-primary/60 rounded-sm transition-all ${previewPlaying ? 'opacity-100' : 'opacity-70'}`}
-                      />
-                    ))}
-                  </div>
+                {/* canvas waveform */}
+                <div className="relative z-10 h-full flex items-center justify-center px-2">
+                  <canvas ref={previewCanvasRef} style={{ width: '100%', height: '100%' }} />
                 </div>
 
                 {/* centered play button (overlay) */}

--- a/src/index.css
+++ b/src/index.css
@@ -138,4 +138,15 @@ All colors MUST be HSL.
   .custom-scrollbar:hover::-webkit-scrollbar-thumb {
     background: hsl(var(--primary) / 0.6);
   }
+
+  /* Hide scrollbar while preserving scroll functionality */
+  .hide-scrollbar {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+  }
+  .hide-scrollbar::-webkit-scrollbar {
+    width: 0px;
+    height: 0px;
+    background: transparent;
+  }
 }

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -274,7 +274,7 @@ const Chat = () => {
                   <>
                     <ConfirmDialog
                       title="Найти нового собеседника?"
-                      description="Текущий диалог будет завершен, и мы найдем вам нового собеседника."
+                      description="Т��кущий диалог будет завершен, и мы найдем вам нового собеседника."
                       onConfirm={handleNextChat}
                     >
                       <Button
@@ -433,7 +433,7 @@ const Chat = () => {
                     onKeyDown={handleKeyPress}
                     placeholder={recState.isRecording || recState.hasRecording ? '' : 'Напишите сообщение...'}
                     disabled={isEnded || !isConnected || recState.isRecording}
-                    className={`w-full h-32 bg-background/80 border-transparent text-foreground placeholder:text-muted-foreground focus:bg-background transition-all rounded-2xl resize-none overflow-y-auto hide-scrollbar ${recState.isRecording || recState.hasRecording ? 'pointer-events-none' : ''} disabled:opacity-70 disabled:cursor-not-allowed`}
+                    className={`w-full h-32 pr-16 bg-background/80 border-transparent text-foreground placeholder:text-muted-foreground focus:bg-background transition-all rounded-2xl resize-none overflow-y-auto hide-scrollbar ${recState.isRecording || recState.hasRecording ? 'pointer-events-none' : ''} disabled:opacity-70 disabled:cursor-not-allowed`}
                     maxLength={500}
                   />
                 </div>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -151,7 +151,7 @@ const Chat = () => {
       setPartnerFound(true);
       setIsConnected(true);
       toast({
-        title: "Новый собеседник найден!",
+        title: "Новый собе��едник найден!",
         description: "Вы подключены к новому чату",
       });
       playSound(CHAT_START_SOUND);
@@ -195,7 +195,7 @@ const Chat = () => {
     });
   };
 
-  const [recState, setRecState] = useState({ isRecording: false, seconds: 0, cancelHint: false, cancelled: false });
+  const [recState, setRecState] = useState({ isRecording: false, seconds: 0, cancelHint: false, cancelled: false, hasRecording: false });
   const cancelRecRef = useRef<(() => void) | null>(null);
   const formatDur = (seconds: number) => {
     const m = Math.floor(seconds / 60).toString().padStart(2, '0');
@@ -396,19 +396,41 @@ const Chat = () => {
             <div className="flex items-end gap-3 max-w-3xl mx-auto flex-wrap">
               <div className="flex-1 min-w-[220px]">
                 <div className={`relative rounded-2xl transition-all duration-200 shadow-[0_2px_16px_0_rgba(80,80,120,0.10)] border border-[rgba(120,110,255,0.25)] bg-background/80 focus-within:border-[rgba(120,110,255,0.7)] focus-within:shadow-[0_0_0_3px_rgba(120,110,255,0.15)] ${isEnded ? 'opacity-60' : 'hover:brightness-105 hover:shadow-[0_2px_24px_0_rgba(120,110,255,0.10)]'}`}>
-                  {recState.isRecording && (
+                  {(recState.isRecording || recState.hasRecording) && (
                     <div className="pointer-events-none absolute inset-x-3 bottom-3 grid grid-cols-3 items-center">
                       <div className="flex items-center gap-2 justify-self-start">
-                        <span className="h-2 w-2 rounded-full bg-red-500 animate-pulse" />
-                        <span className="tabular-nums text-xs text-muted-foreground">{formatDur(recState.seconds)}</span>
+                        {recState.isRecording ? (
+                          <>
+                            <span className="h-2 w-2 rounded-full bg-red-500 animate-pulse" />
+                            <span className="tabular-nums text-xs text-muted-foreground">{formatDur(recState.seconds)}</span>
+                          </>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => cancelRecRef.current?.()}
+                            className="justify-self-start text-muted-foreground inline-flex items-center justify-center h-6 w-6 rounded-full bg-background/60 border border-border/50 hover:bg-background pointer-events-auto"
+                            aria-label="Удалить запись"
+                          >
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0 1 16.138 21H7.862a2 2 0 0 1-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M10 3h4a1 1 0 0 1 1 1v1H9V4a1 1 0 0 1 1-1z" />
+                            </svg>
+                          </button>
+                        )}
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => cancelRecRef.current?.()}
-                        className={`justify-self-center px-2 py-0.5 rounded-md font-medium text-sm pointer-events-auto transition-colors ${recState.cancelled ? 'text-red-400 bg-red-500/10' : 'text-primary bg-primary/10'} drop-shadow-[0_0_6px_hsl(var(--primary))]`}
-                      >
-                        Отмена
-                      </button>
+                      <div className="justify-self-center">
+                        {recState.isRecording ? (
+                          <button
+                            type="button"
+                            onClick={() => cancelRecRef.current?.()}
+                            className={`justify-self-center px-2 py-0.5 rounded-md font-medium text-sm pointer-events-auto transition-colors ${recState.cancelled ? 'text-red-400 bg-red-500/10' : 'text-primary bg-primary/10'} drop-shadow-[0_0_6px_hsl(var(--primary))]`}
+                          >
+                            Отмена
+                          </button>
+                        ) : null}
+                      </div>
+                      <div className="flex items-center justify-self-end">
+                        {/* right empty when recording; when preview available we show nothing here (preview UI is in recorder) */}
+                      </div>
                     </div>
                   )}
                   <Textarea

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -151,7 +151,7 @@ const Chat = () => {
       setPartnerFound(true);
       setIsConnected(true);
       toast({
-        title: "Новый собе��едник найден!",
+        title: "Новый собеседник найден!",
         description: "Вы подключены к новому чату",
       });
       playSound(CHAT_START_SOUND);
@@ -242,20 +242,12 @@ const Chat = () => {
       <div className="bg-pattern" />
       <div className="relative flex flex-col w-full h-full z-10">
           {/* Large decorative background title: centered, slightly larger and rotated */}
-          <h1
-            aria-hidden="true"
-            className="background-title pointer-events-none absolute left-1/2 top-28 -translate-x-1/2 -z-10 text-[clamp(6rem,22vw,18rem)] font-extrabold tracking-tight text-white/6 text-center select-none -rotate-6 blur-sm opacity-18"
-            style={{
-              WebkitMaskImage: 'linear-gradient(180deg, rgba(0,0,0,1) 0%, rgba(0,0,0,0.6) 30%, rgba(0,0,0,0) 70%)',
-              maskImage: 'linear-gradient(180deg, rgba(0,0,0,1) 0%, rgba(0,0,0,0.6) 30%, rgba(0,0,0,0) 70%)',
-              textShadow: '0 20px 60px rgba(0,0,0,0.8)',
-            }}
-          >
-            Bezlico
-          </h1>
         {/* Header */}
         <div className="bg-transparent border-b-0 p-4 animate-fade-in">
-          <div className="max-w-3xl mx-auto">
+          <div className="max-w-3xl mx-auto relative">
+            <h1 aria-hidden="true" className="pointer-events-none absolute inset-x-0 -top-10 -z-10 text-[clamp(5rem,14vw,12rem)] font-extrabold tracking-tight text-white/6 text-center select-none -rotate-6 blur-sm opacity-8" style={{ WebkitMaskImage: 'linear-gradient(180deg, rgba(0,0,0,1) 0%, rgba(0,0,0,0.7) 40%, rgba(0,0,0,0) 75%)' }}>
+              Bezlico
+            </h1>
             <div className="rounded-3xl border border-[rgba(120,110,255,0.18)] bg-background/70 px-3 py-2 flex items-center justify-between flex-wrap gap-2 sm:gap-3">
               <div className="flex items-center space-x-3 flex-shrink min-w-0">
                 <img src="/123.png" alt="Bezlico Logo" className="w-16 h-16 sm:w-20 sm:h-20 rounded-2xl object-contain -my-2" />

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -341,7 +341,7 @@ const Chat = () => {
               </div>
             ) : (
               <div className="h-full flex flex-col">
-                <div className={`rounded-3xl border border-[rgba(120,110,255,0.18)] bg-background/70 shadow-[0_4px_32px_0_rgba(80,80,120,0.10)] px-2 sm:px-6 py-4 min-h-[320px] flex flex-col transition-all duration-200 h-full overflow-y-auto overscroll-contain pr-2 space-y-1 custom-scrollbar ${recState.isRecording || recState.hasRecording ? 'pointer-events-none select-none opacity-80 blur-sm' : ''}` } style={{ scrollbarGutter: 'stable' }}>
+                <div className="rounded-3xl border border-[rgba(120,110,255,0.18)] bg-background/70 shadow-[0_4px_32px_0_rgba(80,80,120,0.10)] px-2 sm:px-6 py-4 min-h-[320px] flex flex-col transition-all duration-200 h-full overflow-y-auto overscroll-contain pr-2 space-y-1 custom-scrollbar" style={{ scrollbarGutter: 'stable' }}>
                   {messages.length > 0 && (
                     <>
                       {messages.map((message, index) => {
@@ -395,7 +395,7 @@ const Chat = () => {
           <div className="bg-transparent border-t-0 p-4 pt-2 animate-slide-up mt-auto">
             <div className="flex items-end gap-3 max-w-3xl mx-auto flex-wrap">
               <div className="flex-1 min-w-[220px]">
-                <div className={`relative rounded-2xl transition-all duration-200 shadow-[0_2px_16px_0_rgba(80,80,120,0.10)] border border-[rgba(120,110,255,0.25)] bg-background/80 focus-within:border-[rgba(120,110,255,0.7)] focus-within:shadow-[0_0_0_3px_rgba(120,110,255,0.15)] ${isEnded ? 'opacity-60' : 'hover:brightness-105 hover:shadow-[0_2px_24px_0_rgba(120,110,255,0.10)]'}`}>
+                <div className={`relative rounded-2xl transition-all duration-200 shadow-[0_2px_16px_0_rgba(80,80,120,0.10)] border border-[rgba(120,110,255,0.25)] bg-background/80 focus-within:border-[rgba(120,110,255,0.7)] focus-within:shadow-[0_0_0_3px_rgba(120,110,255,0.15)] ${isEnded ? 'opacity-60' : 'hover:brightness-105 hover:shadow-[0_2px_24px_0_rgba(120,110,255,0.10)]'} ${recState.isRecording || recState.hasRecording ? 'pointer-events-none select-none opacity-80 blur-sm' : ''}`}>
                   {/* root for voice preview portal */}
                   <div id="voice-preview-root" className="absolute left-3 right-3 bottom-3 flex items-center justify-center pointer-events-auto" />
                   {(recState.isRecording || recState.hasRecording) && (
@@ -442,7 +442,7 @@ const Chat = () => {
                     onKeyDown={handleKeyPress}
                     placeholder={recState.isRecording || recState.hasRecording ? '' : 'Напишите сообщение...'}
                     disabled={isEnded || !isConnected || recState.isRecording}
-                    className={`w-full max-h-64 min-h-[120px] bg-background/80 border-transparent text-foreground placeholder:text-muted-foreground focus:bg-background transition-all rounded-2xl resize-none ${recState.isRecording ? 'pointer-events-none' : ''} disabled:opacity-70 disabled:cursor-not-allowed`}
+                    className={`w-full max-h-64 min-h-[120px] bg-background/80 border-transparent text-foreground placeholder:text-muted-foreground focus:bg-background transition-all rounded-2xl resize-none ${recState.isRecording || recState.hasRecording ? 'pointer-events-none' : ''} disabled:opacity-70 disabled:cursor-not-allowed`}
                     maxLength={500}
                     rows={3}
                   />

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -112,7 +112,7 @@ const Chat = () => {
     }
     addMessage(newMessage, true);
     setNewMessage('');
-    // Симуляция ответа собеседник��
+    // Симуляция ответа собеседника
     setTimeout(() => {
       const responses = [
         "Интересно!",
@@ -289,7 +289,7 @@ const Chat = () => {
                     </ConfirmDialog>
                     <ConfirmDialog
                       title="Завершить чат?"
-                      description="Вы уверены, что хотите покинуть чат и вернуться на главную страницу?"
+                      description="Вы ��верены, что хотите покинуть чат и вернуться на главную страницу?"
                       onConfirm={handleEndChat}
                       destructive
                     >
@@ -341,7 +341,7 @@ const Chat = () => {
               </div>
             ) : (
               <div className="h-full flex flex-col">
-                <div className="rounded-3xl border border-[rgba(120,110,255,0.18)] bg-background/70 shadow-[0_4px_32px_0_rgba(80,80,120,0.10)] px-2 sm:px-6 py-4 min-h-[320px] flex flex-col transition-all duration-200 h-full overflow-y-auto overscroll-contain pr-2 space-y-1 custom-scrollbar" style={{ scrollbarGutter: 'stable' }}>
+                <div className={`rounded-3xl border border-[rgba(120,110,255,0.18)] bg-background/70 shadow-[0_4px_32px_0_rgba(80,80,120,0.10)] px-2 sm:px-6 py-4 min-h-[320px] flex flex-col transition-all duration-200 h-full overflow-y-auto overscroll-contain pr-2 space-y-1 custom-scrollbar ${recState.isRecording || recState.hasRecording ? 'pointer-events-none select-none opacity-80 blur-sm' : ''}` } style={{ scrollbarGutter: 'stable' }}>
                   {messages.length > 0 && (
                     <>
                       {messages.map((message, index) => {

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -55,7 +55,7 @@ const Chat = () => {
       return;
     }
 
-    // Сим��ляция поиска собеседника
+    // Симуляция поиска собеседника
     const searchTimer = setTimeout(() => {
       setIsSearching(false);
       setPartnerFound(true);
@@ -438,43 +438,6 @@ const Chat = () => {
                   />
                 </div>
               </div>
-                {/* Buttons inside input: emoji and voice controls */}
-                <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-auto">
-                  <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
-                    <PopoverTrigger asChild>
-                      <Button variant="outline" size="icon" className="shrink-0 h-10 w-10 bg-background/60 border-border/50 hover:shadow-glow" disabled={isEnded || !isConnected}>
-                        <Smile className="h-4 w-4" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent align="end" className="w-60 p-2">
-                      <div className="grid grid-cols-8 gap-1">
-                        {emojis.map((e) => (
-                          <button
-                            key={e}
-                            type="button"
-                            className="h-7 w-7 rounded-md hover:bg-accent"
-                            onClick={() => { insertAtCursor(e); setEmojiOpen(false); }}
-                          >
-                            {e}
-                          </button>
-                        ))}
-                      </div>
-                    </PopoverContent>
-                  </Popover>
-
-                  <div className="flex items-center">
-                    <VoiceRecorder
-                      disabled={isEnded || !isConnected}
-                      hasText={!!newMessage.trim()}
-                      onSendText={sendMessage}
-                      onRecordingState={setRecState}
-                      onBindApi={({ cancel }) => { cancelRecRef.current = cancel; }}
-                      onSend={({ url, duration }) => {
-                        addAudioMessage(url, duration, true);
-                      }}
-                    />
-                  </div>
-                </div>
             </div>
             <div className="text-xs text-muted-foreground text-center mt-2">
               {newMessage.length}/500 символов

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -55,7 +55,7 @@ const Chat = () => {
       return;
     }
 
-    // Симуляция поиска собеседника
+    // Сим��ляция поиска собеседника
     const searchTimer = setTimeout(() => {
       setIsSearching(false);
       setPartnerFound(true);
@@ -274,7 +274,7 @@ const Chat = () => {
                   <>
                     <ConfirmDialog
                       title="Найти нового собеседника?"
-                      description="Т��кущий диалог будет завершен, и мы найдем вам нового собеседника."
+                      description="Текущий диалог будет завершен, и мы найдем вам нового собеседника."
                       onConfirm={handleNextChat}
                     >
                       <Button
@@ -438,37 +438,43 @@ const Chat = () => {
                   />
                 </div>
               </div>
-              <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
-                <PopoverTrigger asChild>
-                  <Button variant="outline" size="icon" className="shrink-0 h-10 w-10 bg-background/60 border-border/50 hover:shadow-glow" disabled={isEnded || !isConnected}>
-                    <Smile className="h-4 w-4" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent align="end" className="w-60 p-2">
-                  <div className="grid grid-cols-8 gap-1">
-                    {emojis.map((e) => (
-                      <button
-                        key={e}
-                        type="button"
-                        className="h-7 w-7 rounded-md hover:bg-accent"
-                        onClick={() => { insertAtCursor(e); setEmojiOpen(false); }}
-                      >
-                        {e}
-                      </button>
-                    ))}
+                {/* Buttons inside input: emoji and voice controls */}
+                <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-auto">
+                  <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
+                    <PopoverTrigger asChild>
+                      <Button variant="outline" size="icon" className="shrink-0 h-10 w-10 bg-background/60 border-border/50 hover:shadow-glow" disabled={isEnded || !isConnected}>
+                        <Smile className="h-4 w-4" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent align="end" className="w-60 p-2">
+                      <div className="grid grid-cols-8 gap-1">
+                        {emojis.map((e) => (
+                          <button
+                            key={e}
+                            type="button"
+                            className="h-7 w-7 rounded-md hover:bg-accent"
+                            onClick={() => { insertAtCursor(e); setEmojiOpen(false); }}
+                          >
+                            {e}
+                          </button>
+                        ))}
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+
+                  <div className="flex items-center">
+                    <VoiceRecorder
+                      disabled={isEnded || !isConnected}
+                      hasText={!!newMessage.trim()}
+                      onSendText={sendMessage}
+                      onRecordingState={setRecState}
+                      onBindApi={({ cancel }) => { cancelRecRef.current = cancel; }}
+                      onSend={({ url, duration }) => {
+                        addAudioMessage(url, duration, true);
+                      }}
+                    />
                   </div>
-                </PopoverContent>
-              </Popover>
-              <VoiceRecorder
-                disabled={isEnded || !isConnected}
-                hasText={!!newMessage.trim()}
-                onSendText={sendMessage}
-                onRecordingState={setRecState}
-                onBindApi={({ cancel }) => { cancelRecRef.current = cancel; }}
-                onSend={({ url, duration }) => {
-                  addAudioMessage(url, duration, true);
-                }}
-              />
+                </div>
             </div>
             <div className="text-xs text-muted-foreground text-center mt-2">
               {newMessage.length}/500 символов

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -395,7 +395,7 @@ const Chat = () => {
           <div className="bg-transparent border-t-0 p-4 pt-2 animate-slide-up mt-auto">
             <div className="flex items-end gap-3 max-w-3xl mx-auto flex-wrap">
               <div className="flex-1 min-w-[220px]">
-                <div className={`relative rounded-2xl transition-all duration-200 shadow-[0_2px_16px_0_rgba(80,80,120,0.10)] border border-[rgba(120,110,255,0.25)] bg-background/80 focus-within:border-[rgba(120,110,255,0.7)] focus-within:shadow-[0_0_0_3px_rgba(120,110,255,0.15)] ${isEnded ? 'opacity-60' : 'hover:brightness-105 hover:shadow-[0_2px_24px_0_rgba(120,110,255,0.10)]'} ${recState.isRecording || recState.hasRecording ? 'pointer-events-none select-none opacity-80 blur-sm' : ''}`}>
+                <div className={`relative rounded-2xl transition-all duration-200 shadow-[0_2px_16px_0_rgba(80,80,120,0.10)] border border-[rgba(120,110,255,0.25)] bg-background/80 focus-within:border-[rgba(120,110,255,0.7)] focus-within:shadow-[0_0_0_3px_rgba(120,110,255,0.15)] ${isEnded ? 'opacity-60' : 'hover:brightness-105 hover:shadow-[0_2px_24px_0_rgba(120,110,255,0.10)]'} ${recState.isRecording || recState.hasRecording ? 'pointer-events-none select-none opacity-80' : ''}`}>
                   {/* root for voice preview portal */}
                   <div id="voice-preview-root" className="absolute left-3 right-3 bottom-3 flex items-center justify-center pointer-events-auto" />
                   {(recState.isRecording || recState.hasRecording) && (

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -151,7 +151,7 @@ const Chat = () => {
       setPartnerFound(true);
       setIsConnected(true);
       toast({
-        title: "Новый собе��едник найден!",
+        title: "Новый собеседник найден!",
         description: "Вы подключены к новому чату",
       });
       playSound(CHAT_START_SOUND);
@@ -396,6 +396,8 @@ const Chat = () => {
             <div className="flex items-end gap-3 max-w-3xl mx-auto flex-wrap">
               <div className="flex-1 min-w-[220px]">
                 <div className={`relative rounded-2xl transition-all duration-200 shadow-[0_2px_16px_0_rgba(80,80,120,0.10)] border border-[rgba(120,110,255,0.25)] bg-background/80 focus-within:border-[rgba(120,110,255,0.7)] focus-within:shadow-[0_0_0_3px_rgba(120,110,255,0.15)] ${isEnded ? 'opacity-60' : 'hover:brightness-105 hover:shadow-[0_2px_24px_0_rgba(120,110,255,0.10)]'}`}>
+                  {/* root for voice preview portal */}
+                  <div id="voice-preview-root" className="absolute inset-y-0 right-3 flex items-center pointer-events-none" />
                   {(recState.isRecording || recState.hasRecording) && (
                     <div className="pointer-events-none absolute inset-x-3 bottom-3 grid grid-cols-3 items-center">
                       <div className="flex items-center gap-2 justify-self-start">

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -116,7 +116,7 @@ const Chat = () => {
     setTimeout(() => {
       const responses = [
         "Интересно!",
-        "А чт�� думаешь об этом?", 
+        "А что думаешь об этом?", 
         "Согласен",
         "Расскажи подробнее",
         "Понятно",
@@ -241,11 +241,10 @@ const Chat = () => {
       {/* SVG-паттерн для фона */}
       <div className="bg-pattern" />
       <div className="relative flex flex-col w-full h-full z-10">
-          {/* Large decorative background title (subtle, non-intrusive) */}
+          {/* Large decorative background title: centered, slightly larger and rotated */}
           <h1
             aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 top-4 z-0 text-[clamp(4rem,12vw,10rem)] font-extrabold tracking-tight text-white/6 text-center select-none"
-            style={{ WebkitMaskImage: 'linear-gradient(0deg, rgba(0,0,0,0.25) 0%, rgba(0,0,0,1) 40%)', maskImage: 'linear-gradient(0deg, rgba(0,0,0,0.25) 0%, rgba(0,0,0,1) 40%)', opacity: 0.22 }}
+            className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 -z-10 text-[clamp(6rem,18vw,14rem)] font-extrabold tracking-tight text-white/6 text-center select-none -rotate-6 blur-sm opacity-20"
           >
             Bezlico
           </h1>
@@ -259,7 +258,7 @@ const Chat = () => {
                   {isEnded ? (
                     <span>Чат завершён</span>
                   ) : isSearching ? (
-                    <span className="animate-pulse">Поиск собеседника...</span>
+                    <span className="animate-pulse">Поиск ��обеседника...</span>
                   ) : partnerFound ? (
                     <>
                       <div className="flex items-center space-x-1">

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -62,12 +62,12 @@ const Chat = () => {
       setIsConnected(true);
       toast({
         title: "Собеседник найден!",
-        description: "Вы под��лючены к анонимному чату",
+        description: "Вы подключены к анонимному чату",
       });
       playSound(CHAT_START_SOUND);
       // Добавляем приветственное сообщение от системы
       setTimeout(() => {
-        addMessage("При��ет! Как дела?", false);
+        addMessage("Привет! Как дела?", false);
       }, 1000);
     }, Math.random() * 3000 + 1000); // 1-4 секунды
 
@@ -106,7 +106,7 @@ const Chat = () => {
       toast({
         variant: "destructive",
         title: "Сообщение заблокировано",
-        description: "Ваше сообщение содержит запрещенны�� слова",
+        description: "Ваше сообщение содержит запрещенные слова",
       });
       return;
     }
@@ -143,9 +143,9 @@ const Chat = () => {
     setIsSearching(true);
     toast({
       title: "Поиск нового собеседника...",
-      description: "Подождите, мы ищем вам ново��о собеседника",
+      description: "Подождите, мы ищем вам нового собеседника",
     });
-    // Симуляц��я поиска нового собеседника
+    // Симуляция поиска нового собеседника
     setTimeout(() => {
       setIsSearching(false);
       setPartnerFound(true);
@@ -227,7 +227,7 @@ const Chat = () => {
     switch (gender) {
       case 'male': return 'Мужской';
       case 'female': return 'Женский';
-      case 'any': return 'Люб��й';
+      case 'any': return 'Любой';
       default: return gender;
     }
   };
@@ -238,7 +238,7 @@ const Chat = () => {
 
   return (
     <div className="fixed inset-0 w-full h-full overflow-hidden overscroll-none">
-      {/* SVG-паттерн дл�� фона */}
+      {/* SVG-паттерн для фона */}
       <div className="bg-pattern" />
       <div className="relative flex flex-col w-full h-full z-10">
         {/* Header */}
@@ -273,7 +273,7 @@ const Chat = () => {
                   <>
                     <ConfirmDialog
                       title="Найти нового собеседника?"
-                      description="Текущий диалог будет завершен, и мы найдем вам нового собеседника."
+                      description="Текущий диалог будет завер��ен, и мы найдем вам нового собеседника."
                       onConfirm={handleNextChat}
                     >
                       <Button
@@ -308,7 +308,7 @@ const Chat = () => {
                   onClick={handleChangePartner}
                   className="text-xs"
                 >
-                  Сменить параметры по����ска
+                  Сменить параметры поиска
                 </Button>
               </div>
             </div>
@@ -350,7 +350,7 @@ const Chat = () => {
                           const today = new Date();
                           const yesterday = new Date();
                           yesterday.setDate(today.getDate() - 1);
-                          if (d.toDateString() === today.toDateString()) return 'С��годня';
+                          if (d.toDateString() === today.toDateString()) return 'Сегодня';
                           if (d.toDateString() === yesterday.toDateString()) return 'Вчера';
                           return d.toLocaleDateString('ru-RU');
                         })();

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -19,7 +19,7 @@ interface Message {
 }
 
 const CHAT_START_SOUND = "https://cdn.pixabay.com/audio/2022/03/15/audio_115b9b7b44.mp3"; // notify
-const CHAT_END_SOUND = "https://cdn.pixabay.com/audio/2022/03/15/audio_115b9b7b44.mp3"; // можно замени��ь на другой
+const CHAT_END_SOUND = "https://cdn.pixabay.com/audio/2022/03/15/audio_115b9b7b44.mp3"; // можно заменить на другой
 
 function playSound(url: string) {
   const audio = new window.Audio(url);
@@ -48,7 +48,7 @@ const Chat = () => {
   const [isEnded, setIsEnded] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Симуляция подключения к соб��седнику
+  // Симуляция подключения к собеседнику
   useEffect(() => {
     if (!ageCategory || !genderPreference) {
       navigate('/');
@@ -116,7 +116,7 @@ const Chat = () => {
     setTimeout(() => {
       const responses = [
         "Интересно!",
-        "А что думаешь об этом?", 
+        "А чт�� думаешь об этом?", 
         "Согласен",
         "Расскажи подробнее",
         "Понятно",
@@ -241,8 +241,14 @@ const Chat = () => {
       {/* SVG-паттерн для фона */}
       <div className="bg-pattern" />
       <div className="relative flex flex-col w-full h-full z-10">
-          {/* Large decorative background title */}
-          <h1 aria-hidden="true" className="pointer-events-none absolute inset-x-0 top-8 -z-10 text-[clamp(6rem,18vw,14rem)] font-extrabold tracking-tight text-white/6 text-center select-none blur-sm mix-blend-overlay">Bezlico</h1>
+          {/* Large decorative background title (subtle, non-intrusive) */}
+          <h1
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 top-4 z-0 text-[clamp(4rem,12vw,10rem)] font-extrabold tracking-tight text-white/6 text-center select-none"
+            style={{ WebkitMaskImage: 'linear-gradient(0deg, rgba(0,0,0,0.25) 0%, rgba(0,0,0,1) 40%)', maskImage: 'linear-gradient(0deg, rgba(0,0,0,0.25) 0%, rgba(0,0,0,1) 40%)', opacity: 0.22 }}
+          >
+            Bezlico
+          </h1>
         {/* Header */}
         <div className="bg-transparent border-b-0 p-4 animate-fade-in">
           <div className="max-w-3xl mx-auto">

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -67,7 +67,7 @@ const Chat = () => {
       playSound(CHAT_START_SOUND);
       // Добавляем приветственное сообщение от системы
       setTimeout(() => {
-        addMessage("Привет! Как дела?", false);
+        addMessage("При��ет! Как дела?", false);
       }, 1000);
     }, Math.random() * 3000 + 1000); // 1-4 секунды
 
@@ -229,7 +229,7 @@ const Chat = () => {
     switch (gender) {
       case 'male': return 'Мужской';
       case 'female': return 'Женский';
-      case 'any': return 'Любой';
+      case 'any': return 'Люб��й';
       default: return gender;
     }
   };
@@ -289,7 +289,7 @@ const Chat = () => {
                     </ConfirmDialog>
                     <ConfirmDialog
                       title="Завершить чат?"
-                      description="Вы ��верены, что хотите покинуть чат и вернуться на главную страницу?"
+                      description="Вы уверены, что хотите покинуть чат и вернуться на главную страницу?"
                       onConfirm={handleEndChat}
                       destructive
                     >
@@ -440,7 +440,7 @@ const Chat = () => {
                     value={newMessage}
                     onChange={(e) => { setNewMessage(e.target.value); autoResize(); }}
                     onKeyDown={handleKeyPress}
-                    placeholder={recState.isRecording ? '' : 'Напишите сообщение...'}
+                    placeholder={recState.isRecording || recState.hasRecording ? '' : 'Напишите сообщение...'}
                     disabled={isEnded || !isConnected || recState.isRecording}
                     className={`w-full max-h-64 min-h-[120px] bg-background/80 border-transparent text-foreground placeholder:text-muted-foreground focus:bg-background transition-all rounded-2xl resize-none ${recState.isRecording ? 'pointer-events-none' : ''} disabled:opacity-70 disabled:cursor-not-allowed`}
                     maxLength={500}

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -62,7 +62,7 @@ const Chat = () => {
       setIsConnected(true);
       toast({
         title: "Собеседник найден!",
-        description: "Вы под��лючены к анонимному чату",
+        description: "Вы под��лючены к а��онимному чату",
       });
       playSound(CHAT_START_SOUND);
       // Добавляем приветственное сообщение от системы
@@ -174,10 +174,8 @@ const Chat = () => {
   };
 
   const autoResize = () => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = '0px';
-    el.style.height = Math.min(el.scrollHeight, 6 * 24 + 24) + 'px';
+    // Intentionally left empty: we use a fixed textarea height with internal scrolling to prevent
+    // the input from expanding vertically when a lot of text is entered.
   };
 
   const insertAtCursor = (text: string) => {

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -151,7 +151,7 @@ const Chat = () => {
       setPartnerFound(true);
       setIsConnected(true);
       toast({
-        title: "Новый собеседник найден!",
+        title: "Новый собе��едник найден!",
         description: "Вы подключены к новому чату",
       });
       playSound(CHAT_START_SOUND);
@@ -244,7 +244,12 @@ const Chat = () => {
           {/* Large decorative background title: centered, slightly larger and rotated */}
           <h1
             aria-hidden="true"
-            className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 -z-10 text-[clamp(6rem,18vw,14rem)] font-extrabold tracking-tight text-white/6 text-center select-none -rotate-6 blur-sm opacity-20"
+            className="background-title pointer-events-none absolute left-1/2 top-28 -translate-x-1/2 -z-10 text-[clamp(6rem,22vw,18rem)] font-extrabold tracking-tight text-white/6 text-center select-none -rotate-6 blur-sm opacity-18"
+            style={{
+              WebkitMaskImage: 'linear-gradient(180deg, rgba(0,0,0,1) 0%, rgba(0,0,0,0.6) 30%, rgba(0,0,0,0) 70%)',
+              maskImage: 'linear-gradient(180deg, rgba(0,0,0,1) 0%, rgba(0,0,0,0.6) 30%, rgba(0,0,0,0) 70%)',
+              textShadow: '0 20px 60px rgba(0,0,0,0.8)',
+            }}
           >
             Bezlico
           </h1>
@@ -258,7 +263,7 @@ const Chat = () => {
                   {isEnded ? (
                     <span>Чат завершён</span>
                   ) : isSearching ? (
-                    <span className="animate-pulse">Поиск ��обеседника...</span>
+                    <span className="animate-pulse">Поиск собеседника...</span>
                   ) : partnerFound ? (
                     <>
                       <div className="flex items-center space-x-1">

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -62,7 +62,7 @@ const Chat = () => {
       setIsConnected(true);
       toast({
         title: "Собеседник найден!",
-        description: "Вы под��лючены к а��онимному чату",
+        description: "Вы под��лючены к анонимному чату",
       });
       playSound(CHAT_START_SOUND);
       // Добавляем приветственное сообщение от системы
@@ -105,7 +105,7 @@ const Chat = () => {
     if (hasBannedWord) {
       toast({
         variant: "destructive",
-        title: "Сообщение заблокировано",
+        title: "Соо��щение заблокировано",
         description: "Ваше сообщение содержит запрещенны�� слова",
       });
       return;
@@ -145,7 +145,7 @@ const Chat = () => {
       title: "Поиск нового собеседника...",
       description: "Подождите, мы ищем вам ново��о собеседника",
     });
-    // Симуляц��я поиска нового собеседника
+    // Симуляц���я поиска нового собеседника
     setTimeout(() => {
       setIsSearching(false);
       setPartnerFound(true);
@@ -428,13 +428,12 @@ const Chat = () => {
                   <Textarea
                     ref={textareaRef}
                     value={newMessage}
-                    onChange={(e) => { setNewMessage(e.target.value); autoResize(); }}
+                    onChange={(e) => { setNewMessage(e.target.value); }}
                     onKeyDown={handleKeyPress}
                     placeholder={recState.isRecording || recState.hasRecording ? '' : 'Напишите сообщение...'}
                     disabled={isEnded || !isConnected || recState.isRecording}
-                    className={`w-full max-h-64 min-h-[120px] bg-background/80 border-transparent text-foreground placeholder:text-muted-foreground focus:bg-background transition-all rounded-2xl resize-none ${recState.isRecording || recState.hasRecording ? 'pointer-events-none' : ''} disabled:opacity-70 disabled:cursor-not-allowed`}
+                    className={`w-full h-32 bg-background/80 border-transparent text-foreground placeholder:text-muted-foreground focus:bg-background transition-all rounded-2xl resize-none overflow-y-auto ${recState.isRecording || recState.hasRecording ? 'pointer-events-none' : ''} disabled:opacity-70 disabled:cursor-not-allowed`}
                     maxLength={500}
-                    rows={3}
                   />
                 </div>
               </div>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -19,7 +19,7 @@ interface Message {
 }
 
 const CHAT_START_SOUND = "https://cdn.pixabay.com/audio/2022/03/15/audio_115b9b7b44.mp3"; // notify
-const CHAT_END_SOUND = "https://cdn.pixabay.com/audio/2022/03/15/audio_115b9b7b44.mp3"; // можно заменить на другой
+const CHAT_END_SOUND = "https://cdn.pixabay.com/audio/2022/03/15/audio_115b9b7b44.mp3"; // можно замени��ь на другой
 
 function playSound(url: string) {
   const audio = new window.Audio(url);
@@ -48,7 +48,7 @@ const Chat = () => {
   const [isEnded, setIsEnded] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Симуляция подключения к собеседнику
+  // Симуляция подключения к соб��седнику
   useEffect(() => {
     if (!ageCategory || !genderPreference) {
       navigate('/');
@@ -241,6 +241,8 @@ const Chat = () => {
       {/* SVG-паттерн для фона */}
       <div className="bg-pattern" />
       <div className="relative flex flex-col w-full h-full z-10">
+          {/* Large decorative background title */}
+          <h1 aria-hidden="true" className="pointer-events-none absolute inset-x-0 top-8 -z-10 text-[clamp(6rem,18vw,14rem)] font-extrabold tracking-tight text-white/6 text-center select-none blur-sm mix-blend-overlay">Bezlico</h1>
         {/* Header */}
         <div className="bg-transparent border-b-0 p-4 animate-fade-in">
           <div className="max-w-3xl mx-auto">

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -273,7 +273,7 @@ const Chat = () => {
                   <>
                     <ConfirmDialog
                       title="Найти нового собеседника?"
-                      description="Текущий диалог будет завер��ен, и мы найдем вам нового собеседника."
+                      description="Текущий диалог будет завершен, и мы найдем вам нового собеседника."
                       onConfirm={handleNextChat}
                     >
                       <Button

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -105,7 +105,7 @@ const Chat = () => {
     if (hasBannedWord) {
       toast({
         variant: "destructive",
-        title: "Соо��щение заблокировано",
+        title: "Сообщение заблокировано",
         description: "Ваше сообщение содержит запрещенны�� слова",
       });
       return;
@@ -145,7 +145,7 @@ const Chat = () => {
       title: "Поиск нового собеседника...",
       description: "Подождите, мы ищем вам ново��о собеседника",
     });
-    // Симуляц���я поиска нового собеседника
+    // Симуляц��я поиска нового собеседника
     setTimeout(() => {
       setIsSearching(false);
       setPartnerFound(true);
@@ -432,7 +432,7 @@ const Chat = () => {
                     onKeyDown={handleKeyPress}
                     placeholder={recState.isRecording || recState.hasRecording ? '' : 'Напишите сообщение...'}
                     disabled={isEnded || !isConnected || recState.isRecording}
-                    className={`w-full h-32 bg-background/80 border-transparent text-foreground placeholder:text-muted-foreground focus:bg-background transition-all rounded-2xl resize-none overflow-y-auto ${recState.isRecording || recState.hasRecording ? 'pointer-events-none' : ''} disabled:opacity-70 disabled:cursor-not-allowed`}
+                    className={`w-full h-32 bg-background/80 border-transparent text-foreground placeholder:text-muted-foreground focus:bg-background transition-all rounded-2xl resize-none overflow-y-auto hide-scrollbar ${recState.isRecording || recState.hasRecording ? 'pointer-events-none' : ''} disabled:opacity-70 disabled:cursor-not-allowed`}
                     maxLength={500}
                   />
                 </div>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -240,7 +240,7 @@ const Chat = () => {
 
   return (
     <div className="fixed inset-0 w-full h-full overflow-hidden overscroll-none">
-      {/* SVG-паттерн для фона */}
+      {/* SVG-паттерн дл�� фона */}
       <div className="bg-pattern" />
       <div className="relative flex flex-col w-full h-full z-10">
         {/* Header */}
@@ -405,7 +405,7 @@ const Chat = () => {
                       <button
                         type="button"
                         onClick={() => cancelRecRef.current?.()}
-                        className={`justify-self-center text-xs ${recState.cancelled ? 'text-red-400' : 'text-muted-foreground'} pointer-events-auto`}
+                        className={`justify-self-center px-2 py-0.5 rounded-md font-medium text-sm pointer-events-auto transition-colors ${recState.cancelled ? 'text-red-400 bg-red-500/10' : 'text-primary bg-primary/10'} drop-shadow-[0_0_6px_hsl(var(--primary))]`}
                       >
                         Отмена
                       </button>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -395,8 +395,8 @@ const Chat = () => {
             <div className="flex items-end gap-3 max-w-3xl mx-auto flex-wrap">
               <div className="flex-1 min-w-[220px]">
                 <div className={`relative rounded-2xl transition-all duration-200 shadow-[0_2px_16px_0_rgba(80,80,120,0.10)] border border-[rgba(120,110,255,0.25)] bg-background/80 focus-within:border-[rgba(120,110,255,0.7)] focus-within:shadow-[0_0_0_3px_rgba(120,110,255,0.15)] ${isEnded ? 'opacity-60' : 'hover:brightness-105 hover:shadow-[0_2px_24px_0_rgba(120,110,255,0.10)]'} ${recState.isRecording || recState.hasRecording ? 'pointer-events-none select-none opacity-80' : ''}`}>
-                  {/* root for voice preview portal */}
-                  <div id="voice-preview-root" className="absolute left-3 right-3 bottom-3 flex items-center justify-center pointer-events-auto" />
+                  {/* root for voice preview portal (preview will render inside this container) */}
+                  <div id="voice-preview-root" className="absolute left-3 right-20 bottom-3 flex items-center justify-center pointer-events-auto" />
                   {(recState.isRecording || recState.hasRecording) && (
                     <div className="pointer-events-none absolute inset-x-3 bottom-3 grid grid-cols-3 items-center">
                       <div className="flex items-center gap-2 justify-self-start">

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -438,7 +438,7 @@ const Chat = () => {
                   />
 
                   {/* Icons inside input: emoji + voice recorder (aligned) */}
-                  <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-auto">
+                  <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-auto z-20">
                     <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
                       <PopoverTrigger asChild>
                         <Button variant="outline" size="icon" className="shrink-0 h-10 w-10 bg-background/60 border-border/50" disabled={isEnded || !isConnected}>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -106,7 +106,7 @@ const Chat = () => {
       toast({
         variant: "destructive",
         title: "Сообщение заблокировано",
-        description: "Ваше сообщение содержит запрещенные слова",
+        description: "Ваше сообщение содержит запрещенны�� слова",
       });
       return;
     }
@@ -407,16 +407,8 @@ const Chat = () => {
                             <span className="tabular-nums text-xs text-muted-foreground">{formatDur(recState.seconds)}</span>
                           </>
                         ) : (
-                          <button
-                            type="button"
-                            onClick={() => cancelRecRef.current?.()}
-                            className="justify-self-start text-muted-foreground inline-flex items-center justify-center h-6 w-6 rounded-full bg-background/60 border border-border/50 hover:bg-background pointer-events-auto"
-                            aria-label="Удалить запись"
-                          >
-                            <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0 1 16.138 21H7.862a2 2 0 0 1-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M10 3h4a1 1 0 0 1 1 1v1H9V4a1 1 0 0 1 1-1z" />
-                            </svg>
-                          </button>
+                          // left area intentionally empty when preview available (trash moved into pill)
+                          null
                         )}
                       </div>
                       <div className="justify-self-center">

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -245,9 +245,6 @@ const Chat = () => {
         {/* Header */}
         <div className="bg-transparent border-b-0 p-4 animate-fade-in">
           <div className="max-w-3xl mx-auto relative">
-            <h1 aria-hidden="true" className="pointer-events-none absolute inset-x-0 -top-10 -z-10 text-[clamp(5rem,14vw,12rem)] font-extrabold tracking-tight text-white/6 text-center select-none -rotate-6 blur-sm opacity-8" style={{ WebkitMaskImage: 'linear-gradient(180deg, rgba(0,0,0,1) 0%, rgba(0,0,0,0.7) 40%, rgba(0,0,0,0) 75%)' }}>
-              Bezlico
-            </h1>
             <div className="rounded-3xl border border-[rgba(120,110,255,0.18)] bg-background/70 px-3 py-2 flex items-center justify-between flex-wrap gap-2 sm:gap-3">
               <div className="flex items-center space-x-3 flex-shrink min-w-0">
                 <img src="/123.png" alt="Bezlico Logo" className="w-16 h-16 sm:w-20 sm:h-20 rounded-2xl object-contain -my-2" />

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -436,6 +436,44 @@ const Chat = () => {
                     className={`w-full h-32 pr-16 bg-background/80 border-transparent text-foreground placeholder:text-muted-foreground focus:bg-background transition-all rounded-2xl resize-none overflow-y-auto hide-scrollbar ${recState.isRecording || recState.hasRecording ? 'pointer-events-none' : ''} disabled:opacity-70 disabled:cursor-not-allowed`}
                     maxLength={500}
                   />
+
+                  {/* Icons inside input: emoji + voice recorder (aligned) */}
+                  <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-auto">
+                    <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
+                      <PopoverTrigger asChild>
+                        <Button variant="outline" size="icon" className="shrink-0 h-10 w-10 bg-background/60 border-border/50" disabled={isEnded || !isConnected}>
+                          <Smile className="h-4 w-4" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent align="end" className="w-60 p-2">
+                        <div className="grid grid-cols-8 gap-1">
+                          {emojis.map((e) => (
+                            <button
+                              key={e}
+                              type="button"
+                              className="h-7 w-7 rounded-md hover:bg-accent"
+                              onClick={() => { insertAtCursor(e); setEmojiOpen(false); }}
+                            >
+                              {e}
+                            </button>
+                          ))}
+                        </div>
+                      </PopoverContent>
+                    </Popover>
+
+                    <div className="flex items-center">
+                      <VoiceRecorder
+                        disabled={isEnded || !isConnected}
+                        hasText={!!newMessage.trim()}
+                        onSendText={sendMessage}
+                        onRecordingState={setRecState}
+                        onBindApi={({ cancel }) => { cancelRecRef.current = cancel; }}
+                        onSend={({ url, duration }) => {
+                          addAudioMessage(url, duration, true);
+                        }}
+                      />
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -112,7 +112,7 @@ const Chat = () => {
     }
     addMessage(newMessage, true);
     setNewMessage('');
-    // Симуляция ответа собеседника
+    // Симуляция ответа собеседник��
     setTimeout(() => {
       const responses = [
         "Интересно!",
@@ -397,7 +397,7 @@ const Chat = () => {
               <div className="flex-1 min-w-[220px]">
                 <div className={`relative rounded-2xl transition-all duration-200 shadow-[0_2px_16px_0_rgba(80,80,120,0.10)] border border-[rgba(120,110,255,0.25)] bg-background/80 focus-within:border-[rgba(120,110,255,0.7)] focus-within:shadow-[0_0_0_3px_rgba(120,110,255,0.15)] ${isEnded ? 'opacity-60' : 'hover:brightness-105 hover:shadow-[0_2px_24px_0_rgba(120,110,255,0.10)]'}`}>
                   {/* root for voice preview portal */}
-                  <div id="voice-preview-root" className="absolute inset-y-0 right-3 flex items-center pointer-events-none" />
+                  <div id="voice-preview-root" className="absolute left-3 right-3 bottom-3 flex items-center justify-center pointer-events-auto" />
                   {(recState.isRecording || recState.hasRecording) && (
                     <div className="pointer-events-none absolute inset-x-3 bottom-3 grid grid-cols-3 items-center">
                       <div className="flex items-center gap-2 justify-self-start">


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses UI layout issues with the voice recorder component. Users requested:
- Better visual layout to prevent text overlap with chat icons
- More compact and aesthetically pleasing design
- Proper alignment and grouping of all icons (emojis, voice recorder, send button)
- Replacement of arrow icon with logo and improved icon positioning

## Code changes

### VoiceRecorder Component
- **Enhanced waveform visualization**: Added preview waveform with canvas rendering and improved FFT analysis (2048 vs 256)
- **Better audio handling**: Added MediaRecorder API compatibility checks and fallback MIME types
- **Improved recording flow**: Added proper state management for recording/preview phases
- **Visual improvements**: Implemented compact waveform bars with gradient styling and rounded corners

### Chat Component  
- **Layout restructuring**: Moved emoji picker and voice recorder inside the text input area
- **Icon alignment**: Positioned all interactive elements (emoji, voice recorder) in a unified right-side container
- **Input optimization**: Fixed textarea height (h-32) and added proper scrolling behavior
- **State management**: Added pointer-events handling to prevent interaction during recording
- **Text fixes**: Corrected Russian text encoding issues ("Сегодня", "поиска")

### UI/UX Enhancements
- Added voice preview portal system for better component isolation
- Improved visual feedback during recording and preview states
- Enhanced responsive design with proper spacing and alignment
- Added proper disabled states and visual indicatorsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5888e96ee7934f37be973a91d700f8c0/pulse-garden)

👀 [Preview Link](https://5888e96ee7934f37be973a91d700f8c0-pulse-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5888e96ee7934f37be973a91d700f8c0</projectId>-->
<!--<branchName>pulse-garden</branchName>-->